### PR TITLE
[FEAT] 구독 관련 API 구현

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
@@ -63,9 +63,8 @@ public class SubscriptionController {
         }
     )
     @GetMapping("/mypage")
-    public ResponseEntity<BaseResponse> getSubscriptionInfo(
-        @RequestBody SubscriptionDto.SubscriptionInfoRequest request) {
-        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionInfo(request)));
+    public ResponseEntity<BaseResponse> getSubscriptionInfo() {
+        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionInfo()));
     }
 
     @Operation(
@@ -78,9 +77,8 @@ public class SubscriptionController {
         }
     )
     @GetMapping("/status")
-    public ResponseEntity<BaseResponse> getUserStatus(
-        @RequestBody SubscriptionDto.UserStatusRequest request) {
-        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getUserStatus(request)));
+    public ResponseEntity<BaseResponse> getUserStatus() {
+        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getUserStatus()));
     }
 
     @Operation(

--- a/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
@@ -6,24 +6,29 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nextroom.nextRoomServer.dto.BaseResponse;
+import com.nextroom.nextRoomServer.dto.DataResponse;
 import com.nextroom.nextRoomServer.dto.SubscriptionDto;
+import com.nextroom.nextRoomServer.service.SubscriptionService;
 import com.nextroom.nextRoomServer.util.Base64Decoder;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-
 
 @Tag(name = "Subscription")
 @RestController
 @RequestMapping("/api/v1/subscription")
 @RequiredArgsConstructor
 public class SubscriptionController {
+    private final SubscriptionService subscriptionService;
 
     @PostMapping
     public ResponseEntity<BaseResponse> updateSubscription(@RequestBody SubscriptionDto.UpdateSubscription messageDto) {
@@ -40,5 +45,54 @@ public class SubscriptionController {
         }
 
         return ResponseEntity.ok(new BaseResponse(OK));
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<BaseResponse> addSubscription() {
+        subscriptionService.test();
+        return ResponseEntity.ok(new BaseResponse(OK));
+    }
+
+    @Operation(
+        summary = "구독 정보 조회(마이 페이지)",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND")
+        }
+    )
+    @GetMapping("/mypage")
+    public ResponseEntity<BaseResponse> getSubscriptionInfo(
+        @RequestBody SubscriptionDto.SubscriptionInfoRequest request) {
+        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionInfo(request)));
+    }
+
+    @Operation(
+        summary = "유저 상태 조회",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND")
+        }
+    )
+    @GetMapping("/status")
+    public ResponseEntity<BaseResponse> getUserStatus(
+        @RequestBody SubscriptionDto.UserStatusRequest request) {
+        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getUserStatus(request)));
+    }
+
+    @Operation(
+        summary = "구독 요금제 조회",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED")
+        }
+    )
+    @GetMapping("/plan")
+    public ResponseEntity<BaseResponse> getSubscriptionPlan() {
+        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionPlan()));
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -14,6 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,4 +46,7 @@ public class Shop extends Timestamped {
     @OneToMany(mappedBy = "shop", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Theme> themes = new ArrayList<>();
+
+    @OneToOne(mappedBy = "shop", cascade = CascadeType.DETACH)
+    private Subscription subscription;
 }

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
@@ -4,17 +4,19 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
-import com.nextroom.nextRoomServer.enums.SubscriptionStatus;
+import com.nextroom.nextRoomServer.enums.UserStatus;
 import com.nextroom.nextRoomServer.util.Timestamped;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,12 +33,15 @@ public class Subscription extends Timestamped {
     @Column(name = "subscription_id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
 
     private String googleId;
-    private SubscriptionStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+    @Enumerated(EnumType.STRING)
     private SubscriptionPlan plan;
     private LocalDateTime subscribedAt;
     private LocalDate expiryDate;

--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -4,6 +4,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.JsonIOException;
+import com.nextroom.nextRoomServer.domain.Subscription;
+import com.nextroom.nextRoomServer.enums.EnumModel;
+import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
+import com.nextroom.nextRoomServer.enums.UserStatus;
+import com.nextroom.nextRoomServer.util.Timestamped;
 
 import lombok.Getter;
 
@@ -56,6 +61,69 @@ public class SubscriptionDto {
             this.notificationType = Integer.parseInt(subscriptionNotificationMatcher.group(2));
             this.purchaseToken = subscriptionNotificationMatcher.group(3);
             this.subscriptionId = subscriptionNotificationMatcher.group(4);
+        }
+    }
+
+    @Getter
+    public static class SubscriptionInfoRequest {
+        private Long id;
+    }
+
+    @Getter
+    public static class SubscriptionInfoResponse {
+        private final Long id;
+        private final SubscriptionPlan subStatus;
+        private final String expiryDate;
+        private final String subscribedAt;
+        private final String createdAt;
+        private final String modifiedAt;
+
+        public SubscriptionInfoResponse(Subscription subscription) {
+            this.id = subscription.getId();
+            this.subStatus = subscription.getPlan();
+            this.expiryDate = subscription.getExpiryDate().toString();
+            this.subscribedAt = Timestamped.dateTimeFormatter(subscription.getSubscribedAt());
+            this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
+            this.modifiedAt = Timestamped.dateTimeFormatter(subscription.getModifiedAt());
+        }
+    }
+
+    @Getter
+    public static class UserStatusRequest {
+        private Long id;
+    }
+
+    @Getter
+    public static class UserStatusResponse {
+        private final Long id;
+        private final UserStatus userStatus;
+        private final String expiryDate;
+        private final String subscribedAt;
+        private final String createdAt;
+        private final String modifiedAt;
+
+        public UserStatusResponse(Subscription subscription) {
+            this.id = subscription.getId();
+            this.userStatus = subscription.getStatus();
+            this.expiryDate = subscription.getExpiryDate().toString();
+            this.subscribedAt = Timestamped.dateTimeFormatter(subscription.getSubscribedAt());
+            this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
+            this.modifiedAt = Timestamped.dateTimeFormatter(subscription.getModifiedAt());
+        }
+    }
+
+    @Getter
+    public static class SubscriptionPlanResponse {
+        private final String plan;
+        private final String description;
+        private final Integer originPrice;
+        private final Integer sellPrice;
+
+        public SubscriptionPlanResponse(EnumModel enumModel) {
+            this.plan = enumModel.getKey();
+            this.description = enumModel.getDescription();
+            this.originPrice = enumModel.getOriginPrice();
+            this.sellPrice = enumModel.getSellPrice();
         }
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -65,11 +65,6 @@ public class SubscriptionDto {
     }
 
     @Getter
-    public static class SubscriptionInfoRequest {
-        private Long id;
-    }
-
-    @Getter
     public static class SubscriptionInfoResponse {
         private final Long id;
         private final SubscriptionPlan subStatus;
@@ -86,11 +81,6 @@ public class SubscriptionDto {
             this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
             this.modifiedAt = Timestamped.dateTimeFormatter(subscription.getModifiedAt());
         }
-    }
-
-    @Getter
-    public static class UserStatusRequest {
-        private Long id;
     }
 
     @Getter

--- a/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
@@ -1,0 +1,11 @@
+package com.nextroom.nextRoomServer.enums;
+
+public interface EnumModel {
+    String getKey();
+
+    String getDescription();
+
+    Integer getOriginPrice();
+
+    Integer getSellPrice();
+}

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
@@ -1,16 +1,39 @@
 package com.nextroom.nextRoomServer.enums;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public enum SubscriptionPlan {
-    STARTER("2개의 테마를 등록할 수 있어요", 19900, 9900),
-    PRO("5개의 테마를 등록할 수 있어요", 29900, 14900),
-    ENTERPRISE("8개의 테마를 등록할 수 있어요", 39900, 19900);
+public enum SubscriptionPlan implements EnumModel {
+    FREE("무료로 체험할 수 있어요", 0, 0),
+    MINI("2개의 테마를 등록할 수 있어요", 19900, 9900),
+    MEDIUM("5개의 테마를 등록할 수 있어요", 29900, 14900),
+    LARGE("8개의 테마를 등록할 수 있어요", 39900, 19900);
 
     private final String description;
     private final Integer originPrice;
     private final Integer sellPrice;
+
+    SubscriptionPlan(String description, Integer originPrice, Integer sellPrice) {
+        this.description = description;
+        this.originPrice = originPrice;
+        this.sellPrice = sellPrice;
+    }
+
+    @Override
+    public String getKey() {
+        return name();
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public Integer getOriginPrice() {
+        return originPrice;
+    }
+
+    @Override
+    public Integer getSellPrice() {
+        return sellPrice;
+    }
+
 }

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionStatus.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionStatus.java
@@ -1,17 +1,25 @@
 package com.nextroom.nextRoomServer.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum SubscriptionStatus {
-    SUBSCRIPTION_RECOVERED, // 정기 결제가 계정 보류에서 복구되었습니다.
-    SUBSCRIPTION_RENEWED, // 활성 정기 결제가 갱신되었습니다.
-    SUBSCRIPTION_CANCELED, // 정기 결제가 자발적으로 또는 비자발적으로 취소되었습니다. 자발적 취소의 경우 사용자가 취소할 때 전송됩니다.
-    SUBSCRIPTION_PURCHASED, // 새로운 정기 결제가 구매되었습니다.
-    SUBSCRIPTION_ON_HOLD, // 정기 결제가 계정 보류 상태가 되었습니다(사용 설정된 경우).
-    SUBSCRIPTION_IN_GRACE_PERIOD, // 정기 결제가 유예 기간 상태로 전환되었습니다(사용 설정된 경우).
-    SUBSCRIPTION_RESTARTED, // 사용자가 Play > 계정 > 정기 결제에서 정기 결제를 복원했습니다. 정기 결제가 취소되었지만 사용자가 복원할 때 아직 만료되지 않았습니다. 자세한 내용은 복원을 참고하세요.
-    SUBSCRIPTION_PRICE_CHANGE_CONFIRMED, // 사용자가 정기 결제 가격 변경을 확인했습니다.
-    SUBSCRIPTION_DEFERRED, // 구독 갱신 기한이 연장되었습니다.
-    SUBSCRIPTION_PAUSED, // 구독이 일시중지되었습니다.
-    SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED, // 정기 결제 일시중지 일정이 변경되었습니다.
-    SUBSCRIPTION_REVOKED, // 정기 결제가 만료 시간 전에 사용자에 의해 취소되었습니다.
-    SUBSCRIPTION_EXPIRED // 정기 결제가 만료되었습니다.
+    SUBSCRIPTION_RECOVERED(1), // 정기 결제가 계정 보류에서 복구되었습니다.
+    SUBSCRIPTION_RENEWED(2), // 활성 정기 결제가 갱신되었습니다.
+    SUBSCRIPTION_CANCELED(3), // 정기 결제가 자발적으로 또는 비자발적으로 취소되었습니다. 자발적 취소의 경우 사용자가 취소할 때 전송됩니다.
+    SUBSCRIPTION_PURCHASED(4), // 새로운 정기 결제가 구매되었습니다.
+    SUBSCRIPTION_ON_HOLD(5), // 정기 결제가 계정 보류 상태가 되었습니다(사용 설정된 경우).
+    SUBSCRIPTION_IN_GRACE_PERIOD(6), // 정기 결제가 유예 기간 상태로 전환되었습니다(사용 설정된 경우).
+    SUBSCRIPTION_RESTARTED(
+        7), // 사용자가 Play > 계정 > 정기 결제에서 정기 결제를 복원했습니다. 정기 결제가 취소되었지만 사용자가 복원할 때 아직 만료되지 않았습니다. 자세한 내용은 복원을 참고하세요.
+    SUBSCRIPTION_PRICE_CHANGE_CONFIRMED(8), // 사용자가 정기 결제 가격 변경을 확인했습니다.
+    SUBSCRIPTION_DEFERRED(9), // 구독 갱신 기한이 연장되었습니다.
+    SUBSCRIPTION_PAUSED(10), // 구독이 일시중지되었습니다.
+    SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED(11), // 정기 결제 일시중지 일정이 변경되었습니다.
+    SUBSCRIPTION_REVOKED(12), // 정기 결제가 만료 시간 전에 사용자에 의해 취소되었습니다.
+    SUBSCRIPTION_EXPIRED(13); // 정기 결제가 만료되었습니다.
+
+    private final Integer status;
 }

--- a/src/main/java/com/nextroom/nextRoomServer/enums/UserStatus.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/UserStatus.java
@@ -1,0 +1,16 @@
+package com.nextroom.nextRoomServer.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserStatus {
+    FREE("무료 체험"),
+    HOLD("유예 기간"),
+    EXPIRATION("유예 기간 만료"),
+    SUBSCRIPTION("구독"),
+    SUBSCRIPTION_EXPIRATION("구독 만료");
+
+    private final String status;
+}

--- a/src/main/java/com/nextroom/nextRoomServer/repository/SubscriptionRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/SubscriptionRepository.java
@@ -1,0 +1,11 @@
+package com.nextroom.nextRoomServer.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nextroom.nextRoomServer.domain.Subscription;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+    Optional<Subscription> findByShopId(Long id);
+}

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -1,0 +1,77 @@
+package com.nextroom.nextRoomServer.service;
+
+import static com.nextroom.nextRoomServer.enums.SubscriptionPlan.*;
+import static com.nextroom.nextRoomServer.enums.UserStatus.*;
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.nextroom.nextRoomServer.domain.Shop;
+import com.nextroom.nextRoomServer.domain.Subscription;
+import com.nextroom.nextRoomServer.dto.SubscriptionDto;
+import com.nextroom.nextRoomServer.enums.EnumModel;
+import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
+import com.nextroom.nextRoomServer.exceptions.CustomException;
+import com.nextroom.nextRoomServer.repository.ShopRepository;
+import com.nextroom.nextRoomServer.repository.SubscriptionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+    private final SubscriptionRepository subscriptionRepository;
+    private final ShopRepository shopRepository;
+
+    public void test() {
+        Shop shop = shopRepository.findByAdminCode("12321").orElseThrow(
+            () -> new RuntimeException("ERROR"));
+
+        Subscription entity = Subscription.builder()
+            .shop(shop)
+            .googleId("test")
+            .status(SUBSCRIPTION)
+            .plan(MINI)
+            .subscribedAt(LocalDateTime.now().plusDays(30))
+            .expiryDate(LocalDate.now())
+            .build();
+        subscriptionRepository.save(entity);
+    }
+
+    public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo(
+        SubscriptionDto.SubscriptionInfoRequest request) {
+        Subscription subscription = subscriptionRepository.findByShopId(request.getId()).orElseThrow(
+            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
+
+        return new SubscriptionDto.SubscriptionInfoResponse(subscription);
+    }
+
+    public SubscriptionDto.UserStatusResponse getUserStatus(SubscriptionDto.UserStatusRequest request) {
+        Subscription subscription = subscriptionRepository.findByShopId(request.getId()).orElseThrow(
+            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
+
+        return new SubscriptionDto.UserStatusResponse(subscription);
+    }
+
+    public Map<String, List<SubscriptionDto.SubscriptionPlanResponse>> getSubscriptionPlan() {
+        Map<String, List<SubscriptionDto.SubscriptionPlanResponse>> enumValues = new LinkedHashMap<>();
+        enumValues.put("SubscriptionPlan", toEnumValues(SubscriptionPlan.class));
+
+        return enumValues;
+    }
+
+    private List<SubscriptionDto.SubscriptionPlanResponse> toEnumValues(Class<? extends EnumModel> e) {
+        return Arrays
+            .stream(e.getEnumConstants())
+            .map(SubscriptionDto.SubscriptionPlanResponse::new)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -22,6 +22,7 @@ import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
 import com.nextroom.nextRoomServer.exceptions.CustomException;
 import com.nextroom.nextRoomServer.repository.ShopRepository;
 import com.nextroom.nextRoomServer.repository.SubscriptionRepository;
+import com.nextroom.nextRoomServer.security.SecurityUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -40,28 +41,31 @@ public class SubscriptionService {
             .googleId("test")
             .status(SUBSCRIPTION)
             .plan(MINI)
-            .subscribedAt(LocalDateTime.now().plusDays(30))
-            .expiryDate(LocalDate.now())
+            .subscribedAt(LocalDateTime.now())
+            .expiryDate(LocalDate.now().plusDays(30))
             .build();
         subscriptionRepository.save(entity);
     }
 
-    public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo(
-        SubscriptionDto.SubscriptionInfoRequest request) {
-        Subscription subscription = subscriptionRepository.findByShopId(request.getId()).orElseThrow(
+    public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo() {
+        Long shopId = SecurityUtil.getRequestedShopId();
+        Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
             () -> new CustomException(TARGET_SHOP_NOT_FOUND));
 
         return new SubscriptionDto.SubscriptionInfoResponse(subscription);
     }
 
-    public SubscriptionDto.UserStatusResponse getUserStatus(SubscriptionDto.UserStatusRequest request) {
-        Subscription subscription = subscriptionRepository.findByShopId(request.getId()).orElseThrow(
+    public SubscriptionDto.UserStatusResponse getUserStatus() {
+        Long shopId = SecurityUtil.getRequestedShopId();
+        Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
             () -> new CustomException(TARGET_SHOP_NOT_FOUND));
 
         return new SubscriptionDto.UserStatusResponse(subscription);
     }
 
     public Map<String, List<SubscriptionDto.SubscriptionPlanResponse>> getSubscriptionPlan() {
+        Long shopId = SecurityUtil.getRequestedShopId();
+        subscriptionRepository.findByShopId(shopId).orElseThrow(() -> new CustomException(TARGET_SHOP_NOT_FOUND));
         Map<String, List<SubscriptionDto.SubscriptionPlanResponse>> enumValues = new LinkedHashMap<>();
         enumValues.put("SubscriptionPlan", toEnumValues(SubscriptionPlan.class));
 


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/sub-api → feature/subscription

### 작업 사항
- 기존 ManyToOne이었던 Shop과 Subscription의 관계를 OneToOne으로 변경
- 구독 관련 Enum 정의
  - SubscriptionStatus(구글 기준 구독 상태)
  - UserStatus(프로덕트 기준 유저 상태)
  - SubscriptionPlan(구독 요금제)
- 구독 관련 API 구현
  - 마이페이지에서 필요한 API
  - 유저 상태 API (테마 선택 페이지)
  - 이용권 정보 API (이용권 정보 페이지)
- 안드로이드와의 빠른 테스트를 위해 핵심 로직 먼저 구현하였습니다.
Service단의 예외 처리는 추후 진행하겠습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
Postman 테스트 결과 이상 없습니다!