### PR TITLE
[REFACTOR] Refresh Token으로 Token 재발급 로직 재정비

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/dto/AuthDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/AuthDto.java
@@ -105,6 +105,8 @@ public class AuthDto {
 
     @Getter
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor(force = true)
     public static class ReissueRequestDto {
         private String accessToken;
         private String refreshToken;

--- a/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
@@ -24,7 +24,6 @@ public enum StatusCode {
      * 401 Unauthorized
      */
     TOKEN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한 정보가 잘못된 토큰입니다."),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
     SHOP_IS_LOG_OUT(HttpStatus.UNAUTHORIZED, "로그아웃 된 사용자입니다."),
 
     /**
@@ -42,6 +41,11 @@ public enum StatusCode {
     TARGET_THEME_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 테마입니다."),
     TARGET_HINT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 힌트입니다."),
     TARGET_SHOP_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 업체입니다."),
+
+    /**
+     * 407 Proxy Authentication Required
+     */
+    TOKEN_EXPIRED(HttpStatus.PROXY_AUTHENTICATION_REQUIRED, "만료된 토큰입니다."),
 
     /**
      * 409 Conflict

--- a/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
@@ -33,8 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 12; // 12시간
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
 
     private final Key key;
 


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링 (#76)

### 반영 브랜치
feature/refresh-token → develop

### 작업 사항
- ReissueRequestDto에 생성자 추가
- Token 만료 응답 코드 407로 변경
- Token 유효 기간 변경
  - Access Token : 2시간
  - Refresh Token : 14일

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다!