### PR TITLE
[REFACTOR] 안드로이드용 API 삭제

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/controller/HintController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/HintController.java
@@ -3,7 +3,6 @@ package com.nextroom.nextRoomServer.controller;
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -57,9 +56,6 @@ public class HintController {
     )
     @GetMapping
     public ResponseEntity<BaseResponse> getHintList(@RequestParam("themeId") Long themeId) {
-        if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() == "anonymousUser") {
-            return ResponseEntity.ok(new DataResponse<>(OK, hintService.getHintListByThemeId(themeId)));
-        }
         return ResponseEntity.ok(new DataResponse<>(OK, hintService.getHintList(themeId)));
     }
 

--- a/src/main/java/com/nextroom/nextRoomServer/controller/ThemeController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/ThemeController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nextroom.nextRoomServer.dto.BaseResponse;
@@ -57,9 +56,8 @@ public class ThemeController {
         }
     )
     @GetMapping
-    public ResponseEntity<BaseResponse> getThemeList(
-        @RequestParam(value = "adminCode", required = false) String adminCode) {
-        return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList(adminCode)));
+    public ResponseEntity<BaseResponse> getThemeList() {
+        return ResponseEntity.ok(new DataResponse<>(OK, themeService.getThemeList()));
     }
 
     @Operation(

--- a/src/main/java/com/nextroom/nextRoomServer/service/HintService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/HintService.java
@@ -62,12 +62,6 @@ public class HintService {
         return theme.getHints().stream().map(HintDto.HintListResponse::new).toList();
     }
 
-    public Object getHintListByThemeId(Long themeId) {
-        Theme theme = themeRepository.findById(themeId).orElseThrow(() -> new CustomException(TARGET_THEME_NOT_FOUND));
-
-        return theme.getHints().stream().map(HintDto.HintListResponse::new).toList();
-    }
-
     @Transactional
     public void editHint(HintDto.EditHintRequest request) {
         Hint hint = hintRepository.findById(request.getId()).orElseThrow(


### PR DESCRIPTION
### PR 타입
- [x] 기능 삭제 (#78)

### 반영 브랜치
feature/android-api → develop

### 작업 사항
- 테마 조회 API 와 힌트 조회 API의 인가 방식을 AdminCode가 아닌 토큰 방식으로 변경하면서 AdminCode 인가 로직을 삭제하였습니다.
- ThemeService의 validate 관련 메서드들의 이름만 보았을 때 객체를 리턴한다는 행위를 예측하기 어렵다는 의견(https://github.com/Next-Room/NextRoom-be/pull/43#discussion_r1276602700) 에 따라 get으로 메서드 이름을 변경하였습니다. (ex. validateShop → getShop)

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과, 토큰이 없는 요청에 200 응답이 오는 걸 확인했습니다.
해당 이슈(#39)는 추후 처리하겠습니다.