### PR TITLE
[REFACTOR] 구독 요금제 API 수정

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -71,7 +71,7 @@ public class SubscriptionDto {
 
     @Getter
     public static class SubscriptionPlanResponse {
-        private final Integer id;
+        private final String id;
         private final String plan;
         private final String description;
         private final Integer originPrice;
@@ -79,7 +79,7 @@ public class SubscriptionDto {
 
         public SubscriptionPlanResponse(EnumModel enumModel) {
             this.id = enumModel.getId();
-            this.plan = enumModel.getKey();
+            this.plan = enumModel.getPlan();
             this.description = enumModel.getDescription();
             this.originPrice = enumModel.getOriginPrice();
             this.sellPrice = enumModel.getSellPrice();

--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -1,9 +1,5 @@
 package com.nextroom.nextRoomServer.dto;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import com.google.gson.JsonIOException;
 import com.nextroom.nextRoomServer.domain.Subscription;
 import com.nextroom.nextRoomServer.enums.EnumModel;
 import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
@@ -75,12 +71,14 @@ public class SubscriptionDto {
 
     @Getter
     public static class SubscriptionPlanResponse {
+        private final Integer id;
         private final String plan;
         private final String description;
         private final Integer originPrice;
         private final Integer sellPrice;
 
         public SubscriptionPlanResponse(EnumModel enumModel) {
+            this.id = enumModel.getId();
             this.plan = enumModel.getKey();
             this.description = enumModel.getDescription();
             this.originPrice = enumModel.getOriginPrice();

--- a/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
@@ -3,7 +3,9 @@ package com.nextroom.nextRoomServer.enums;
 public interface EnumModel {
     String getKey();
 
-    Integer getId();
+    String getId();
+
+    String getPlan();
 
     String getDescription();
 

--- a/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
@@ -3,6 +3,8 @@ package com.nextroom.nextRoomServer.enums;
 public interface EnumModel {
     String getKey();
 
+    Integer getId();
+
     String getDescription();
 
     Integer getOriginPrice();

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
@@ -1,9 +1,9 @@
 package com.nextroom.nextRoomServer.enums;
 
 public enum SubscriptionPlan implements EnumModel {
-    MINI("2", "미니", "2개의 테마를 등록할 수 있어요", 19900, 9900),
-    MEDIUM("3", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900),
-    LARGE("4", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900);
+    MINI("mini_subscription", "미니", "2개의 테마를 등록할 수 있어요", 19900, 9900),
+    MEDIUM("medium_subscription", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900),
+    LARGE("large_subscription", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900);
 
     private final String id;
     private final String plan;

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
@@ -1,15 +1,17 @@
 package com.nextroom.nextRoomServer.enums;
 
 public enum SubscriptionPlan implements EnumModel {
-    MINI("2개의 테마를 등록할 수 있어요", 19900, 9900),
-    MEDIUM("5개의 테마를 등록할 수 있어요", 29900, 14900),
-    LARGE("8개의 테마를 등록할 수 있어요", 39900, 19900);
+    MINI(2, "2개의 테마를 등록할 수 있어요", 19900, 9900),
+    MEDIUM(3, "5개의 테마를 등록할 수 있어요", 29900, 14900),
+    LARGE(4, "8개의 테마를 등록할 수 있어요", 39900, 19900);
 
+    private final Integer id;
     private final String description;
     private final Integer originPrice;
     private final Integer sellPrice;
 
-    SubscriptionPlan(String description, Integer originPrice, Integer sellPrice) {
+    SubscriptionPlan(Integer id, String description, Integer originPrice, Integer sellPrice) {
+        this.id = id;
         this.description = description;
         this.originPrice = originPrice;
         this.sellPrice = sellPrice;
@@ -18,6 +20,11 @@ public enum SubscriptionPlan implements EnumModel {
     @Override
     public String getKey() {
         return name();
+    }
+
+    @Override
+    public Integer getId() {
+        return id;
     }
 
     @Override

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
@@ -1,17 +1,19 @@
 package com.nextroom.nextRoomServer.enums;
 
 public enum SubscriptionPlan implements EnumModel {
-    MINI(2, "2개의 테마를 등록할 수 있어요", 19900, 9900),
-    MEDIUM(3, "5개의 테마를 등록할 수 있어요", 29900, 14900),
-    LARGE(4, "8개의 테마를 등록할 수 있어요", 39900, 19900);
+    MINI("2", "미니", "2개의 테마를 등록할 수 있어요", 19900, 9900),
+    MEDIUM("3", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900),
+    LARGE("4", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900);
 
-    private final Integer id;
+    private final String id;
+    private final String plan;
     private final String description;
     private final Integer originPrice;
     private final Integer sellPrice;
 
-    SubscriptionPlan(Integer id, String description, Integer originPrice, Integer sellPrice) {
+    SubscriptionPlan(String id, String plan, String description, Integer originPrice, Integer sellPrice) {
         this.id = id;
+        this.plan = plan;
         this.description = description;
         this.originPrice = originPrice;
         this.sellPrice = sellPrice;
@@ -23,8 +25,13 @@ public enum SubscriptionPlan implements EnumModel {
     }
 
     @Override
-    public Integer getId() {
+    public String getId() {
         return id;
+    }
+
+    @Override
+    public String getPlan() {
+        return plan;
     }
 
     @Override

--- a/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
@@ -67,8 +67,8 @@ public class SecurityConfig {
                 authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry
                     .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/**", "/api/v1/payment/**")
                     .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/v1/subscription/plan")
-                    .permitAll() // Android 구독 요금제 조회
+                    .requestMatchers(HttpMethod.GET, "/api/v1/theme/**", "/api/v1/hint/**", "/api/v1/subscription/**")
+                    .permitAll() // TODO 구독 상태에 다른 권한 설정 필요
                     .requestMatchers("/api/v1/theme/**")
                     .hasAnyAuthority("ROLE_USER")
                     .anyRequest()

--- a/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
@@ -67,8 +67,8 @@ public class SecurityConfig {
                 authorizationManagerRequestMatcherRegistry -> authorizationManagerRequestMatcherRegistry
                     .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/**", "/api/v1/payment/**")
                     .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/v1/theme/**", "/api/v1/hint/**")
-                    .permitAll() // Android 인증 면제
+                    .requestMatchers(HttpMethod.GET, "/api/v1/subscription/plan")
+                    .permitAll() // Android 구독 요금제 조회
                     .requestMatchers("/api/v1/theme/**")
                     .hasAnyAuthority("ROLE_USER")
                     .anyRequest()

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -6,9 +6,7 @@ import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
 
 import java.time.LocalDate;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -61,11 +59,8 @@ public class SubscriptionService {
         return new SubscriptionDto.UserStatusResponse(subscription);
     }
 
-    public Map<String, List<SubscriptionDto.SubscriptionPlanResponse>> getSubscriptionPlan() {
-        Map<String, List<SubscriptionDto.SubscriptionPlanResponse>> enumValues = new LinkedHashMap<>();
-        enumValues.put("SubscriptionPlan", toEnumValues(SubscriptionPlan.class));
-
-        return enumValues;
+    public List<SubscriptionDto.SubscriptionPlanResponse> getSubscriptionPlan() {
+        return toEnumValues(SubscriptionPlan.class);
     }
 
     private List<SubscriptionDto.SubscriptionPlanResponse> toEnumValues(Class<? extends EnumModel> e) {


### PR DESCRIPTION
### PR 타입
- [x] 기능 수정 (#83)

### 반영 브랜치
feature/sub-api → develop

### 작업 사항
- 구독 API 서버 배포 후, 클라이언트 피드백에 따라 다음과 같이 변경합니다.
  - 구독 상품 고유 id 추가 (String 타입)
  - API 응답 시, SubscriptionPlan 키 제외
  - 토큰 없이 요청 가능 하도록 구현
  - 구독 plan 이름 영어에서 한글로 변경
- **추가+)** SecurityConfig 변경 후 이전에 해결했던 이슈(#39)가 다시 발생하는 것을 확인했습니다. 이전 상태로 돌려놨고, 추후 구독 상태에 따른 권한 설정 시 처리 할 예정입니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다!