### PR TITLE
[FEAT] 30일 무료체험 구현

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
@@ -43,4 +43,10 @@ public class Subscription extends Timestamped {
     @Enumerated(EnumType.STRING)
     private SubscriptionPlan plan;
     private LocalDate expiryDate;
+
+    public void updateStatus(UserStatus userStatus, LocalDate expiryDate, SubscriptionPlan plan) {
+        this.status = userStatus;
+        this.expiryDate = expiryDate;
+        this.plan = plan;
+    }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -72,6 +72,7 @@ public class SubscriptionService {
 
         if (status == FREE && expiryDate.isBefore(Timestamped.getToday())) {
             subscription.updateStatus(HOLD, expiryDate.plusYears(1), null);
+            return;
         }
 
         if (status == HOLD && expiryDate.isBefore(Timestamped.getToday())) {

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -10,16 +10,19 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.nextroom.nextRoomServer.domain.Shop;
 import com.nextroom.nextRoomServer.domain.Subscription;
 import com.nextroom.nextRoomServer.dto.SubscriptionDto;
 import com.nextroom.nextRoomServer.enums.EnumModel;
 import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
+import com.nextroom.nextRoomServer.enums.UserStatus;
 import com.nextroom.nextRoomServer.exceptions.CustomException;
 import com.nextroom.nextRoomServer.repository.ShopRepository;
 import com.nextroom.nextRoomServer.repository.SubscriptionRepository;
 import com.nextroom.nextRoomServer.security.SecurityUtil;
+import com.nextroom.nextRoomServer.util.Timestamped;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,6 +46,7 @@ public class SubscriptionService {
         subscriptionRepository.save(entity);
     }
 
+    @Transactional(readOnly = true)
     public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo() {
         Long shopId = SecurityUtil.getRequestedShopId();
         Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
@@ -51,14 +55,31 @@ public class SubscriptionService {
         return new SubscriptionDto.SubscriptionInfoResponse(subscription);
     }
 
+    @Transactional
     public SubscriptionDto.UserStatusResponse getUserStatus() {
         Long shopId = SecurityUtil.getRequestedShopId();
         Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
             () -> new CustomException(TARGET_SHOP_NOT_FOUND));
 
+        checkUserStatus(subscription);
+
         return new SubscriptionDto.UserStatusResponse(subscription);
     }
 
+    private void checkUserStatus(Subscription subscription) {
+        UserStatus status = subscription.getStatus();
+        LocalDate expiryDate = subscription.getExpiryDate();
+
+        if (status == FREE && expiryDate.isBefore(Timestamped.getToday())) {
+            subscription.updateStatus(HOLD, expiryDate.plusYears(1), null);
+        }
+
+        if (status == HOLD && expiryDate.isBefore(Timestamped.getToday())) {
+            // subscriptionRepository.delete(subscription);
+        }
+    }
+
+    @Transactional(readOnly = true)
     public List<SubscriptionDto.SubscriptionPlanResponse> getSubscriptionPlan() {
         return toEnumValues(SubscriptionPlan.class);
     }

--- a/src/main/java/com/nextroom/nextRoomServer/util/Timestamped.java
+++ b/src/main/java/com/nextroom/nextRoomServer/util/Timestamped.java
@@ -1,5 +1,6 @@
 package com.nextroom.nextRoomServer.util;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
@@ -26,6 +27,10 @@ public class Timestamped {
 
     public static String dateTimeFormatter(LocalDateTime localDateTime) {
         return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    public static LocalDate getToday() {
+        return LocalDate.now();
     }
 
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 (#86)

### 반영 브랜치
feature/free-status → develop

### 작업 사항
- 회원 가입 시, 구독 정보(무료 체험) 함께 생성 되도록 구현하였습니다.
  - 이 때 생성 되는 구독 정보는 **FREE** status와 **MINI** plan을 갖습니다.
- 30일 무료체험 → 유예 → 유예 만료로 진행되는 상태 변경 로직을 구현하였습니다.
  - userStatus 요청 시, 해당 유저의 status와 expiryDate를 고려하여 상태를 변경합니다.
  - 기존 정책대로 유예 만료 시 데이터 삭제를 구현하였으나, 추후 변동 사항이 생길 경우를 대비하여 현재 주석 처리 해 둔 상태입니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다.