### PR TITLE
[FEAT] 통계를 위한 play history API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
-    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/nextroom/nextRoomServer/controller/HistoryController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/HistoryController.java
@@ -1,0 +1,42 @@
+package com.nextroom.nextRoomServer.controller;
+
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nextroom.nextRoomServer.dto.BaseResponse;
+import com.nextroom.nextRoomServer.dto.HistoryDto;
+import com.nextroom.nextRoomServer.service.HistoryService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "History")
+@RestController
+@RequestMapping("/api/v1/history")
+@RequiredArgsConstructor
+public class HistoryController {
+    private final HistoryService historyService;
+
+    @Operation(
+        summary = "히스토리 기록",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND"),
+            @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+        }
+    )
+    @PostMapping
+    public ResponseEntity<BaseResponse> addHistory(@RequestBody HistoryDto.AddPlayHistoryRequest request) {
+        historyService.addHistory(request);
+        return ResponseEntity.ok(new BaseResponse(OK));
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/domain/HintHistory.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/HintHistory.java
@@ -1,0 +1,43 @@
+package com.nextroom.nextRoomServer.domain;
+
+import java.time.LocalDateTime;
+
+import com.nextroom.nextRoomServer.util.Timestamped;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HintHistory extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "hint_history_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "play_history_id", nullable = false)
+    private PlayHistory playHistory;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "hint_id", nullable = false)
+    private Hint hint;
+
+    @Column(nullable = false)
+    private LocalDateTime entryTime;
+
+    private LocalDateTime answerOpenTime;
+}

--- a/src/main/java/com/nextroom/nextRoomServer/domain/PlayHistory.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/PlayHistory.java
@@ -1,9 +1,9 @@
 package com.nextroom.nextRoomServer.domain;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.nextroom.nextRoomServer.dto.ThemeDto;
 import com.nextroom.nextRoomServer.util.Timestamped;
 
 import jakarta.persistence.CascadeType;
@@ -26,33 +26,21 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Theme extends Timestamped {
+public class PlayHistory extends Timestamped {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "theme_id", nullable = false)
+    @Column(name = "play_history_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "shop_id", nullable = false)
-    private Shop shop;
+    @JoinColumn(name = "theme_id", nullable = false)
+    private Theme theme;
 
     @Column(nullable = false)
-    private String title;
+    private LocalDateTime gameStartTime;
 
-    private Integer timeLimit;
-    private Integer hintLimit;
-
-    @OneToMany(mappedBy = "theme", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "playHistory", cascade = CascadeType.ALL)
     @Builder.Default
-    private List<Hint> hints = new ArrayList<>();
+    private List<HintHistory> hints = new ArrayList<>();
 
-    @OneToMany(mappedBy = "theme", cascade = CascadeType.ALL)
-    @Builder.Default
-    private List<PlayHistory> playHistories = new ArrayList<>();
-
-    public void update(ThemeDto.EditThemeRequest request) {
-        this.title = request.getTitle();
-        this.timeLimit = request.getTimeLimit();
-        this.hintLimit = request.getHintLimit();
-    }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/dto/HistoryDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/HistoryDto.java
@@ -1,0 +1,36 @@
+package com.nextroom.nextRoomServer.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+public class HistoryDto {
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    @NoArgsConstructor(force = true)
+    public static class AddPlayHistoryRequest {
+        private final Long themeId;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private final LocalDateTime gameStartTime;
+        private final List<AddHintHistoryRequest> hint;
+    }
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    @NoArgsConstructor(force = true)
+    public static class AddHintHistoryRequest {
+        private final Long id;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private final LocalDateTime entryTime;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+        private final LocalDateTime answerOpenTime;
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/repository/HintHistoryRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/HintHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.nextroom.nextRoomServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nextroom.nextRoomServer.domain.HintHistory;
+
+public interface HintHistoryRepository extends JpaRepository<HintHistory, Long> {
+}

--- a/src/main/java/com/nextroom/nextRoomServer/repository/PlayHistoryRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/PlayHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.nextroom.nextRoomServer.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nextroom.nextRoomServer.domain.PlayHistory;
+
+public interface PlayHistoryRepository extends JpaRepository<PlayHistory, Long> {
+}

--- a/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 public class SecurityConfig {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;

--- a/src/main/java/com/nextroom/nextRoomServer/service/HistoryService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/HistoryService.java
@@ -1,0 +1,62 @@
+package com.nextroom.nextRoomServer.service;
+
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+
+import java.util.Objects;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nextroom.nextRoomServer.domain.Hint;
+import com.nextroom.nextRoomServer.domain.HintHistory;
+import com.nextroom.nextRoomServer.domain.PlayHistory;
+import com.nextroom.nextRoomServer.domain.Theme;
+import com.nextroom.nextRoomServer.dto.HistoryDto;
+import com.nextroom.nextRoomServer.exceptions.CustomException;
+import com.nextroom.nextRoomServer.repository.HintHistoryRepository;
+import com.nextroom.nextRoomServer.repository.HintRepository;
+import com.nextroom.nextRoomServer.repository.PlayHistoryRepository;
+import com.nextroom.nextRoomServer.repository.ThemeRepository;
+import com.nextroom.nextRoomServer.security.SecurityUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HistoryService {
+    private final PlayHistoryRepository playHistoryRepository;
+    private final HintHistoryRepository hintHistoryRepository;
+    private final ThemeRepository themeRepository;
+    private final HintRepository hintRepository;
+
+    @Transactional
+    public void addHistory(HistoryDto.AddPlayHistoryRequest request) {
+        Theme theme = themeRepository.findById(request.getThemeId())
+            .orElseThrow(() -> new CustomException(TARGET_THEME_NOT_FOUND));
+
+        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
+            throw new CustomException(NOT_PERMITTED);
+        }
+
+        PlayHistory playHistory = PlayHistory.builder()
+            .theme(theme)
+            .gameStartTime(request.getGameStartTime())
+            .build();
+
+        playHistory = playHistoryRepository.saveAndFlush(playHistory);
+
+        for (HistoryDto.AddHintHistoryRequest hintHistoryRequest : request.getHint()) {
+            Hint hint = hintRepository.findById(hintHistoryRequest.getId()).orElseThrow(
+                () -> new CustomException(TARGET_HINT_NOT_FOUND));
+
+            HintHistory hintHistory = HintHistory.builder()
+                .playHistory(playHistory)
+                .hint(hint)
+                .entryTime(hintHistoryRequest.getEntryTime())
+                .answerOpenTime(hintHistoryRequest.getAnswerOpenTime())
+                .build();
+
+            hintHistoryRepository.save(hintHistory);
+        }
+    }
+}


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 (#89)

### 반영 브랜치
feature/analytics → develop

### 작업 사항
- 플레이 데이터를 수집하기 위해 play history API를 구현하였습니다.
- 그 외 작업 사항
  - 더 이상 사용하지 않는 h2database 관련 설정을 제거하였습니다.
  - Security 관련 Log 설정을 해제 하였습니다. Log의 양이 많기 때문에 이 설정은 local에서만 사용하는 게 좋아 보입니다!

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman API 테스트 결과 이상 없습니다.