### PR TITLE
[FEAT] 구독 플랜에 따른 테마 생성 개수 제한

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/EnumModel.java
@@ -12,4 +12,6 @@ public interface EnumModel {
     Integer getOriginPrice();
 
     Integer getSellPrice();
+
+    Integer getThemeLimitCount();
 }

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
@@ -1,22 +1,25 @@
 package com.nextroom.nextRoomServer.enums;
 
 public enum SubscriptionPlan implements EnumModel {
-    MINI("mini_subscription", "미니", "2개의 테마를 등록할 수 있어요", 19900, 9900),
-    MEDIUM("medium_subscription", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900),
-    LARGE("large_subscription", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900);
+    MINI("mini_subscription", "미니", "2개의 테마를 등록할 수 있어요", 19900, 9900, 2),
+    MEDIUM("medium_subscription", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900, 3),
+    LARGE("large_subscription", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900, 4);
 
     private final String id;
     private final String plan;
     private final String description;
     private final Integer originPrice;
     private final Integer sellPrice;
+    private final Integer themeLimitCount;
 
-    SubscriptionPlan(String id, String plan, String description, Integer originPrice, Integer sellPrice) {
+    SubscriptionPlan(String id, String plan, String description, Integer originPrice, Integer sellPrice,
+        Integer themeLimitCount) {
         this.id = id;
         this.plan = plan;
         this.description = description;
         this.originPrice = originPrice;
         this.sellPrice = sellPrice;
+        this.themeLimitCount = themeLimitCount;
     }
 
     @Override
@@ -47,6 +50,11 @@ public enum SubscriptionPlan implements EnumModel {
     @Override
     public Integer getSellPrice() {
         return sellPrice;
+    }
+
+    @Override
+    public Integer getThemeLimitCount() {
+        return themeLimitCount;
     }
 
 }

--- a/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
@@ -15,6 +15,7 @@ public enum StatusCode {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     LOGIN_BAD_REQUEST(HttpStatus.BAD_REQUEST, "관리자 코드 또는 패스워드가 일치하지 않습니다."),
     SHOP_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "업체가 이미 존재합니다."),
+    THEME_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "테마 생성 최대 개수를 초과하였습니다."),
 
     /**
      * 401 Unauthorized

--- a/src/main/java/com/nextroom/nextRoomServer/repository/ThemeRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/ThemeRepository.java
@@ -5,15 +5,12 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.nextroom.nextRoomServer.domain.Shop;
 import com.nextroom.nextRoomServer.domain.Theme;
 
 public interface ThemeRepository extends JpaRepository<Theme, Long> {
     Optional<Theme> findByTitle(String title);
 
-    List<Theme> findAllByShop(Shop shop);
+    List<Theme> findAllByShopId(Long shopId);
 
-    Optional<Theme> findByIdAndShop(Long id, Shop shop);
-
-    boolean existsByIdAndShop(Long themeId, Shop shop);
+    Integer countByShopId(Long ShopId);
 }


### PR DESCRIPTION
### PR 타입
- [X] 기능 추가 (#90)

### 반영 브랜치
feature/theme-limit → develop

### 작업 사항
- SubscriptionPlan Enum에 각 구독 플랜 별 테마 생성 제한 개수 정보를 추가하였습니다.
- 테마를 생성하기 전, 해당 유저가 구독하고 있는 플랜에 따라 테마 생성 가능 여부를 판단합니다. 최대 개수를 초과했을 경우, 예외 처리 하도록 구현하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman으로 api 테스트 결과 이상 없습니다!