### PR TITLE
[CHORE] 토큰 만료 시간 수정

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
@@ -33,10 +33,8 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-//    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
-//    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60; // 1분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 5;  // 5분
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
 
     private final Key key;
 


### PR DESCRIPTION
### PR 타입
- [x] 코드 수정 (#93)

### 반영 브랜치
feature/token-expire-time → develop

### 작업 사항
- 안드로이드 테스트가 충분히 진행되었다고 합니다. 토큰 만료 시간을 원래대로 돌려 놓았습니다!
  - Access Token : 1분 → 2시간
  - Refresh Token : 5분 → 14일

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 이상 없습니다.