### PR TITLE
[FEAT] 통계 문제별 평균 힌트 사용 횟수 API 구현

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/controller/HistoryController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/HistoryController.java
@@ -3,12 +3,15 @@ package com.nextroom.nextRoomServer.controller;
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nextroom.nextRoomServer.dto.BaseResponse;
+import com.nextroom.nextRoomServer.dto.DataResponse;
 import com.nextroom.nextRoomServer.dto.HistoryDto;
 import com.nextroom.nextRoomServer.service.HistoryService;
 
@@ -38,5 +41,20 @@ public class HistoryController {
     public ResponseEntity<BaseResponse> addHistory(@RequestBody HistoryDto.AddPlayHistoryRequest request) {
         historyService.addHistory(request);
         return ResponseEntity.ok(new BaseResponse(OK));
+    }
+
+    @Operation(
+        summary = "문제별 평균 힌트 사용 횟수",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND"),
+            @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+        }
+    )
+    @GetMapping
+    public ResponseEntity<BaseResponse> getThemeAnalytics(@RequestParam("themeId") Long themeId) {
+        return ResponseEntity.ok(new DataResponse<>(OK, historyService.getThemeAnalytics(themeId)));
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/dto/HistoryDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/HistoryDto.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 
 public class HistoryDto {
     @Getter
-    @Builder
     @RequiredArgsConstructor
     @NoArgsConstructor(force = true)
     public static class AddPlayHistoryRequest {
@@ -23,7 +22,6 @@ public class HistoryDto {
     }
 
     @Getter
-    @Builder
     @RequiredArgsConstructor
     @NoArgsConstructor(force = true)
     public static class AddHintHistoryRequest {
@@ -32,5 +30,25 @@ public class HistoryDto {
         private final LocalDateTime entryTime;
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
         private final LocalDateTime answerOpenTime;
+    }
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    @NoArgsConstructor(force = true)
+    public static class ThemeAnalyticsResponse {
+        private final Long themeId;
+        private final Integer totalPlayCount;
+        private final List<HintAnalyticsListResponse> hint;
+    }
+
+    @Getter
+    @Builder
+    @RequiredArgsConstructor
+    @NoArgsConstructor(force = true)
+    public static class HintAnalyticsListResponse {
+        private final Long id;
+        private final Integer hintOpenCount;
+        private final Integer answerOpenCount;
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/repository/HintHistoryRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/HintHistoryRepository.java
@@ -1,8 +1,20 @@
 package com.nextroom.nextRoomServer.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.nextroom.nextRoomServer.domain.HintHistory;
 
 public interface HintHistoryRepository extends JpaRepository<HintHistory, Long> {
+    @Query(value = "SELECT A.hint_id AS id, COUNT(A.hint_id) AS hintOpenCount, SUM(A.answer_count) AS answerOpenCount "
+        +
+        "FROM (SELECT hint_id, IF(answer_open_time IS NULL, 0, 1) AS answer_count " +
+        "FROM play_history PH " +
+        "INNER JOIN hint_history HH ON PH.play_history_id = HH.play_history_id " +
+        "WHERE PH.theme_id = :themeId) A " +
+        "GROUP BY A.hint_id", nativeQuery = true)
+    List<Object[]> findAnalyticsByThemeId(@Param("themeId") Long themeId);
 }

--- a/src/main/java/com/nextroom/nextRoomServer/repository/PlayHistoryRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/PlayHistoryRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.nextroom.nextRoomServer.domain.PlayHistory;
 
 public interface PlayHistoryRepository extends JpaRepository<PlayHistory, Long> {
+    Integer countByThemeId(Long themeId);
 }


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가 (#96)

### 반영 브랜치
feature/analytics → develop

### 작업 사항
- 웹 대시보드를 위해 문제별 평균 힌트 사용 횟수 API를 구현하였습니다.
- 힌트 사용 횟수 리스트를 가져오는 쿼리가 복잡하여 native query를 사용하였습니다.
```java
public interface HintHistoryRepository extends JpaRepository<HintHistory, Long> {
    @Query(value = "SELECT A.hint_id AS id, COUNT(A.hint_id) AS hintOpenCount, SUM(A.answer_count) AS answerOpenCount "
        +
        "FROM (SELECT hint_id, IF(answer_open_time IS NULL, 0, 1) AS answer_count " +
        "FROM play_history PH " +
        "INNER JOIN hint_history HH ON PH.play_history_id = HH.play_history_id " +
        "WHERE PH.theme_id = :themeId) A " +
        "GROUP BY A.hint_id", nativeQuery = true)
    List<Object[]> findAnalyticsByThemeId(@Param("themeId") Long themeId);
}
```
- 자세한 요청과 응답에 대한 명세는 [API 명세서](https://www.notion.so/ee5caac74de04a7a8febcd3b6d5de035)를 참고해주세요.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없습니다!