### PR TITLE
[REFACTOR] 구독 결제 & 통계 기능 제거

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/controller/HistoryController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/HistoryController.java
@@ -1,60 +1,60 @@
-package com.nextroom.nextRoomServer.controller;
-
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.nextroom.nextRoomServer.dto.BaseResponse;
-import com.nextroom.nextRoomServer.dto.DataResponse;
-import com.nextroom.nextRoomServer.dto.HistoryDto;
-import com.nextroom.nextRoomServer.service.HistoryService;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-
-@Tag(name = "History")
-@RestController
-@RequestMapping("/api/v1/history")
-@RequiredArgsConstructor
-public class HistoryController {
-    private final HistoryService historyService;
-
-    @Operation(
-        summary = "히스토리 기록",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
-            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
-            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND"),
-            @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
-        }
-    )
-    @PostMapping
-    public ResponseEntity<BaseResponse> addHistory(@RequestBody HistoryDto.AddPlayHistoryRequest request) {
-        historyService.addHistory(request);
-        return ResponseEntity.ok(new BaseResponse(OK));
-    }
-
-    @Operation(
-        summary = "문제별 평균 힌트 사용 횟수",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
-            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
-            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND"),
-            @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
-        }
-    )
-    @GetMapping
-    public ResponseEntity<BaseResponse> getThemeAnalytics(@RequestParam("themeId") Long themeId) {
-        return ResponseEntity.ok(new DataResponse<>(OK, historyService.getThemeAnalytics(themeId)));
-    }
-}
+//package com.nextroom.nextRoomServer.controller;
+//
+//import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+//
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RequestParam;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import com.nextroom.nextRoomServer.dto.BaseResponse;
+//import com.nextroom.nextRoomServer.dto.DataResponse;
+//import com.nextroom.nextRoomServer.dto.HistoryDto;
+//import com.nextroom.nextRoomServer.service.HistoryService;
+//
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.responses.ApiResponse;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//
+//@Tag(name = "History")
+//@RestController
+//@RequestMapping("/api/v1/history")
+//@RequiredArgsConstructor
+//public class HistoryController {
+//    private final HistoryService historyService;
+//
+//    @Operation(
+//        summary = "히스토리 기록",
+//        responses = {
+//            @ApiResponse(responseCode = "200", description = "OK"),
+//            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+//            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+//            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND"),
+//            @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+//        }
+//    )
+//    @PostMapping
+//    public ResponseEntity<BaseResponse> addHistory(@RequestBody HistoryDto.AddPlayHistoryRequest request) {
+//        historyService.addHistory(request);
+//        return ResponseEntity.ok(new BaseResponse(OK));
+//    }
+//
+//    @Operation(
+//        summary = "문제별 평균 힌트 사용 횟수",
+//        responses = {
+//            @ApiResponse(responseCode = "200", description = "OK"),
+//            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+//            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+//            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND"),
+//            @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+//        }
+//    )
+//    @GetMapping
+//    public ResponseEntity<BaseResponse> getThemeAnalytics(@RequestParam("themeId") Long themeId) {
+//        return ResponseEntity.ok(new DataResponse<>(OK, historyService.getThemeAnalytics(themeId)));
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/controller/PaymentController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/PaymentController.java
@@ -1,71 +1,71 @@
-package com.nextroom.nextRoomServer.controller;
-
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
-
-import java.io.IOException;
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nextroom.nextRoomServer.dto.BaseResponse;
-import com.nextroom.nextRoomServer.dto.SubscriptionDto;
-import com.nextroom.nextRoomServer.enums.SubscriptionStatus;
-import com.nextroom.nextRoomServer.service.SubscriptionService;
-import com.nextroom.nextRoomServer.util.Base64Decoder;
-
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-
-@Tag(name = "Payment")
-@RestController
-@RequestMapping("/api/v1/payment")
-@RequiredArgsConstructor
-public class PaymentController {
-
-    private final SubscriptionService subscriptionService;
-
-    @PostMapping("/purchase")
-    public ResponseEntity<BaseResponse> purchaseSubscription(
-        @RequestBody SubscriptionDto.PurchaseSubscription request
-    ) throws IOException {
-        subscriptionService.purchaseSubscription(request.getPurchaseToken(), request.getSubscriptionId());
-        return ResponseEntity.ok(new BaseResponse(OK));
-    }
-
-    @PostMapping("/rtdn")
-    public ResponseEntity<BaseResponse> updateSubscriptionPurchase(
-        @RequestBody SubscriptionDto.UpdateSubscription requestBody
-    ) throws
-        Exception {
-        String decodedData = Base64Decoder.decode(requestBody.getMessage().getData());
-
-        Pattern pattern = Pattern.compile(
-            ".*\"subscriptionNotification\":\\{(.*?)\\}.*");
-        Matcher matcher = pattern.matcher(decodedData);
-
-        String notificationContent = matcher.group(1);
-        ObjectMapper objectMapper = new ObjectMapper();
-        SubscriptionDto.PublishedMessage publishedMessage = objectMapper.readValue(decodedData,
-            SubscriptionDto.PublishedMessage.class);
-        System.out.println(publishedMessage.getSubscriptionNotification().getPurchaseToken());
-
-        //     TODO handle exception
-        Integer notificationType = publishedMessage.getSubscriptionNotification().getNotificationType();
-        String purchaseToken = publishedMessage.getSubscriptionNotification().getPurchaseToken();
-        String subscriptionId = publishedMessage.getSubscriptionNotification().getSubscriptionId();
-
-        if (Objects.equals(notificationType, SubscriptionStatus.SUBSCRIPTION_RENEWED.getStatus())) {
-            subscriptionService.renew(purchaseToken, subscriptionId);
-        } else if (Objects.equals(notificationType, SubscriptionStatus.SUBSCRIPTION_EXPIRED.getStatus())) {
-            subscriptionService.expire(purchaseToken);
-        }
-        return ResponseEntity.ok(new BaseResponse(OK));
-    }
-}
+//package com.nextroom.nextRoomServer.controller;
+//
+//import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+//
+//import java.io.IOException;
+//import java.util.Objects;
+//import java.util.regex.Matcher;
+//import java.util.regex.Pattern;
+//
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.nextroom.nextRoomServer.dto.BaseResponse;
+//import com.nextroom.nextRoomServer.dto.SubscriptionDto;
+//import com.nextroom.nextRoomServer.enums.SubscriptionStatus;
+//import com.nextroom.nextRoomServer.service.SubscriptionService;
+//import com.nextroom.nextRoomServer.util.Base64Decoder;
+//
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//
+//@Tag(name = "Payment")
+//@RestController
+//@RequestMapping("/api/v1/payment")
+//@RequiredArgsConstructor
+//public class PaymentController {
+//
+//    private final SubscriptionService subscriptionService;
+//
+//    @PostMapping("/purchase")
+//    public ResponseEntity<BaseResponse> purchaseSubscription(
+//        @RequestBody SubscriptionDto.PurchaseSubscription request
+//    ) throws IOException {
+//        subscriptionService.purchaseSubscription(request.getPurchaseToken(), request.getSubscriptionId());
+//        return ResponseEntity.ok(new BaseResponse(OK));
+//    }
+//
+//    @PostMapping("/rtdn")
+//    public ResponseEntity<BaseResponse> updateSubscriptionPurchase(
+//        @RequestBody SubscriptionDto.UpdateSubscription requestBody
+//    ) throws
+//        Exception {
+//        String decodedData = Base64Decoder.decode(requestBody.getMessage().getData());
+//
+//        Pattern pattern = Pattern.compile(
+//            ".*\"subscriptionNotification\":\\{(.*?)\\}.*");
+//        Matcher matcher = pattern.matcher(decodedData);
+//
+//        String notificationContent = matcher.group(1);
+//        ObjectMapper objectMapper = new ObjectMapper();
+//        SubscriptionDto.PublishedMessage publishedMessage = objectMapper.readValue(decodedData,
+//            SubscriptionDto.PublishedMessage.class);
+//        System.out.println(publishedMessage.getSubscriptionNotification().getPurchaseToken());
+//
+//        //     TODO handle exception
+//        Integer notificationType = publishedMessage.getSubscriptionNotification().getNotificationType();
+//        String purchaseToken = publishedMessage.getSubscriptionNotification().getPurchaseToken();
+//        String subscriptionId = publishedMessage.getSubscriptionNotification().getSubscriptionId();
+//
+//        if (Objects.equals(notificationType, SubscriptionStatus.SUBSCRIPTION_RENEWED.getStatus())) {
+//            subscriptionService.renew(purchaseToken, subscriptionId);
+//        } else if (Objects.equals(notificationType, SubscriptionStatus.SUBSCRIPTION_EXPIRED.getStatus())) {
+//            subscriptionService.expire(purchaseToken);
+//        }
+//        return ResponseEntity.ok(new BaseResponse(OK));
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
@@ -1,96 +1,96 @@
-package com.nextroom.nextRoomServer.controller;
-
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.nextroom.nextRoomServer.dto.BaseResponse;
-import com.nextroom.nextRoomServer.dto.DataResponse;
-import com.nextroom.nextRoomServer.dto.SubscriptionDto;
-import com.nextroom.nextRoomServer.service.SubscriptionService;
-import com.nextroom.nextRoomServer.util.Base64Decoder;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-
-@Tag(name = "Subscription")
-@RestController
-@RequestMapping("/api/v1/subscription")
-@RequiredArgsConstructor
-public class SubscriptionController {
-    private final SubscriptionService subscriptionService;
-
-    @PostMapping
-    public ResponseEntity<BaseResponse> updateSubscription(@RequestBody SubscriptionDto.UpdateSubscription messageDto) {
-        String decodedData = Base64Decoder.decode(messageDto.getMessage().getData());
-
-        System.out.println(decodedData);
-
-        Pattern pattern = Pattern.compile(".*\"testNotification\":\\{(.*?)\\}.*");
-        Matcher matcher = pattern.matcher(decodedData);
-
-        if (matcher.find()) {
-            String notificationContent = matcher.group(1);
-            System.out.println("Extracted Notification Content: " + notificationContent);
-        }
-
-        return ResponseEntity.ok(new BaseResponse(OK));
-    }
-
-    @PostMapping("/test")
-    public ResponseEntity<BaseResponse> addSubscription() {
-        subscriptionService.test();
-        return ResponseEntity.ok(new BaseResponse(OK));
-    }
-
-    @Operation(
-        summary = "구독 정보 조회(마이 페이지)",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
-            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
-            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND")
-        }
-    )
-    @GetMapping("/mypage")
-    public ResponseEntity<BaseResponse> getSubscriptionInfo() {
-        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionInfo()));
-    }
-
-    @Operation(
-        summary = "유저 상태 조회",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
-            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
-            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND")
-        }
-    )
-    @GetMapping("/status")
-    public ResponseEntity<BaseResponse> getUserStatus() {
-        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getUserStatus()));
-    }
-
-    @Operation(
-        summary = "구독 요금제 조회",
-        responses = {
-            @ApiResponse(responseCode = "200", description = "OK"),
-            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
-            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED")
-        }
-    )
-    @GetMapping("/plan")
-    public ResponseEntity<BaseResponse> getSubscriptionPlan() {
-        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionPlan()));
-    }
-}
+//package com.nextroom.nextRoomServer.controller;
+//
+//import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+//
+//import java.util.regex.Matcher;
+//import java.util.regex.Pattern;
+//
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.GetMapping;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import com.nextroom.nextRoomServer.dto.BaseResponse;
+//import com.nextroom.nextRoomServer.dto.DataResponse;
+//import com.nextroom.nextRoomServer.dto.SubscriptionDto;
+//import com.nextroom.nextRoomServer.service.SubscriptionService;
+//import com.nextroom.nextRoomServer.util.Base64Decoder;
+//
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.responses.ApiResponse;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//
+//@Tag(name = "Subscription")
+//@RestController
+//@RequestMapping("/api/v1/subscription")
+//@RequiredArgsConstructor
+//public class SubscriptionController {
+//    private final SubscriptionService subscriptionService;
+//
+//    @PostMapping
+//    public ResponseEntity<BaseResponse> updateSubscription(@RequestBody SubscriptionDto.UpdateSubscription messageDto) {
+//        String decodedData = Base64Decoder.decode(messageDto.getMessage().getData());
+//
+//        System.out.println(decodedData);
+//
+//        Pattern pattern = Pattern.compile(".*\"testNotification\":\\{(.*?)\\}.*");
+//        Matcher matcher = pattern.matcher(decodedData);
+//
+//        if (matcher.find()) {
+//            String notificationContent = matcher.group(1);
+//            System.out.println("Extracted Notification Content: " + notificationContent);
+//        }
+//
+//        return ResponseEntity.ok(new BaseResponse(OK));
+//    }
+//
+//    @PostMapping("/test")
+//    public ResponseEntity<BaseResponse> addSubscription() {
+//        subscriptionService.test();
+//        return ResponseEntity.ok(new BaseResponse(OK));
+//    }
+//
+//    @Operation(
+//        summary = "구독 정보 조회(마이 페이지)",
+//        responses = {
+//            @ApiResponse(responseCode = "200", description = "OK"),
+//            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+//            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+//            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND")
+//        }
+//    )
+//    @GetMapping("/mypage")
+//    public ResponseEntity<BaseResponse> getSubscriptionInfo() {
+//        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionInfo()));
+//    }
+//
+//    @Operation(
+//        summary = "유저 상태 조회",
+//        responses = {
+//            @ApiResponse(responseCode = "200", description = "OK"),
+//            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+//            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+//            @ApiResponse(responseCode = "404", description = "TARGET_SHOP_NOT_FOUND")
+//        }
+//    )
+//    @GetMapping("/status")
+//    public ResponseEntity<BaseResponse> getUserStatus() {
+//        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getUserStatus()));
+//    }
+//
+//    @Operation(
+//        summary = "구독 요금제 조회",
+//        responses = {
+//            @ApiResponse(responseCode = "200", description = "OK"),
+//            @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+//            @ApiResponse(responseCode = "403", description = "NOT_PERMITTED")
+//        }
+//    )
+//    @GetMapping("/plan")
+//    public ResponseEntity<BaseResponse> getSubscriptionPlan() {
+//        return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionPlan()));
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/domain/HintHistory.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/HintHistory.java
@@ -1,43 +1,43 @@
-package com.nextroom.nextRoomServer.domain;
-
-import java.time.LocalDateTime;
-
-import com.nextroom.nextRoomServer.util.Timestamped;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Entity
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class HintHistory extends Timestamped {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "hint_history_id", nullable = false)
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "play_history_id", nullable = false)
-    private PlayHistory playHistory;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "hint_id", nullable = false)
-    private Hint hint;
-
-    @Column(nullable = false)
-    private LocalDateTime entryTime;
-
-    private LocalDateTime answerOpenTime;
-}
+//package com.nextroom.nextRoomServer.domain;
+//
+//import java.time.LocalDateTime;
+//
+//import com.nextroom.nextRoomServer.util.Timestamped;
+//
+//import jakarta.persistence.Column;
+//import jakarta.persistence.Entity;
+//import jakarta.persistence.FetchType;
+//import jakarta.persistence.GeneratedValue;
+//import jakarta.persistence.GenerationType;
+//import jakarta.persistence.Id;
+//import jakarta.persistence.JoinColumn;
+//import jakarta.persistence.ManyToOne;
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//
+//@Entity
+//@Getter
+//@Builder
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class HintHistory extends Timestamped {
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    @Column(name = "hint_history_id", nullable = false)
+//    private Long id;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "play_history_id", nullable = false)
+//    private PlayHistory playHistory;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "hint_id", nullable = false)
+//    private Hint hint;
+//
+//    @Column(nullable = false)
+//    private LocalDateTime entryTime;
+//
+//    private LocalDateTime answerOpenTime;
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/domain/PlayHistory.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/PlayHistory.java
@@ -1,46 +1,46 @@
-package com.nextroom.nextRoomServer.domain;
-
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-
-import com.nextroom.nextRoomServer.util.Timestamped;
-
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Entity
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class PlayHistory extends Timestamped {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "play_history_id", nullable = false)
-    private Long id;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "theme_id", nullable = false)
-    private Theme theme;
-
-    @Column(nullable = false)
-    private LocalDateTime gameStartTime;
-
-    @OneToMany(mappedBy = "playHistory", cascade = CascadeType.ALL)
-    @Builder.Default
-    private List<HintHistory> hints = new ArrayList<>();
-
-}
+//package com.nextroom.nextRoomServer.domain;
+//
+//import java.time.LocalDateTime;
+//import java.util.ArrayList;
+//import java.util.List;
+//
+//import com.nextroom.nextRoomServer.util.Timestamped;
+//
+//import jakarta.persistence.CascadeType;
+//import jakarta.persistence.Column;
+//import jakarta.persistence.Entity;
+//import jakarta.persistence.FetchType;
+//import jakarta.persistence.GeneratedValue;
+//import jakarta.persistence.GenerationType;
+//import jakarta.persistence.Id;
+//import jakarta.persistence.JoinColumn;
+//import jakarta.persistence.ManyToOne;
+//import jakarta.persistence.OneToMany;
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//
+//@Entity
+//@Getter
+//@Builder
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class PlayHistory extends Timestamped {
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    @Column(name = "play_history_id", nullable = false)
+//    private Long id;
+//
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "theme_id", nullable = false)
+//    private Theme theme;
+//
+//    @Column(nullable = false)
+//    private LocalDateTime gameStartTime;
+//
+//    @OneToMany(mappedBy = "playHistory", cascade = CascadeType.ALL)
+//    @Builder.Default
+//    private List<HintHistory> hints = new ArrayList<>();
+//
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -47,6 +47,6 @@ public class Shop extends Timestamped {
     @Builder.Default
     private List<Theme> themes = new ArrayList<>();
 
-    @OneToOne(mappedBy = "shop", cascade = CascadeType.DETACH)
-    private Subscription subscription;
+//    @OneToOne(mappedBy = "shop", cascade = CascadeType.DETACH)
+//    private Subscription subscription;
 }

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Subscription.java
@@ -44,17 +44,17 @@ public class Subscription extends Timestamped {
     @Column(unique = true)
     private String purchaseToken;
 
-    public void renew(LocalDate expiryDate) {
-        this.expiryDate = expiryDate;
-    }
-
-    public void expire() {
-        this.status = UserStatus.EXPIRATION;
-    }
-
-    public void updateStatus(UserStatus userStatus, LocalDate expiryDate, SubscriptionPlan plan) {
-        this.status = userStatus;
-        this.expiryDate = expiryDate;
-        this.plan = plan;
-    }
+//    public void renew(LocalDate expiryDate) {
+//        this.expiryDate = expiryDate;
+//    }
+//
+//    public void expire() {
+//        this.status = UserStatus.EXPIRATION;
+//    }
+//
+//    public void updateStatus(UserStatus userStatus, LocalDate expiryDate, SubscriptionPlan plan) {
+//        this.status = userStatus;
+//        this.expiryDate = expiryDate;
+//        this.plan = plan;
+//    }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Theme.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Theme.java
@@ -46,9 +46,9 @@ public class Theme extends Timestamped {
     @Builder.Default
     private List<Hint> hints = new ArrayList<>();
 
-    @OneToMany(mappedBy = "theme", cascade = CascadeType.ALL)
-    @Builder.Default
-    private List<PlayHistory> playHistories = new ArrayList<>();
+//    @OneToMany(mappedBy = "theme", cascade = CascadeType.ALL)
+//    @Builder.Default
+//    private List<PlayHistory> playHistories = new ArrayList<>();
 
     public void update(ThemeDto.EditThemeRequest request) {
         this.title = request.getTitle();

--- a/src/main/java/com/nextroom/nextRoomServer/dto/HistoryDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/HistoryDto.java
@@ -1,54 +1,54 @@
-package com.nextroom.nextRoomServer.dto;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
-
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-
-public class HistoryDto {
-    @Getter
-    @RequiredArgsConstructor
-    @NoArgsConstructor(force = true)
-    public static class AddPlayHistoryRequest {
-        private final Long themeId;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        private final LocalDateTime gameStartTime;
-        private final List<AddHintHistoryRequest> hint;
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    @NoArgsConstructor(force = true)
-    public static class AddHintHistoryRequest {
-        private final Long id;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        private final LocalDateTime entryTime;
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
-        private final LocalDateTime answerOpenTime;
-    }
-
-    @Getter
-    @Builder
-    @RequiredArgsConstructor
-    @NoArgsConstructor(force = true)
-    public static class ThemeAnalyticsResponse {
-        private final Long themeId;
-        private final Integer totalPlayCount;
-        private final List<HintAnalyticsListResponse> hint;
-    }
-
-    @Getter
-    @Builder
-    @RequiredArgsConstructor
-    @NoArgsConstructor(force = true)
-    public static class HintAnalyticsListResponse {
-        private final Long id;
-        private final Integer hintOpenCount;
-        private final Integer answerOpenCount;
-    }
-}
+//package com.nextroom.nextRoomServer.dto;
+//
+//import java.time.LocalDateTime;
+//import java.util.List;
+//
+//import com.fasterxml.jackson.annotation.JsonFormat;
+//
+//import lombok.Builder;
+//import lombok.Getter;
+//import lombok.NoArgsConstructor;
+//import lombok.RequiredArgsConstructor;
+//
+//public class HistoryDto {
+//    @Getter
+//    @RequiredArgsConstructor
+//    @NoArgsConstructor(force = true)
+//    public static class AddPlayHistoryRequest {
+//        private final Long themeId;
+//        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+//        private final LocalDateTime gameStartTime;
+//        private final List<AddHintHistoryRequest> hint;
+//    }
+//
+//    @Getter
+//    @RequiredArgsConstructor
+//    @NoArgsConstructor(force = true)
+//    public static class AddHintHistoryRequest {
+//        private final Long id;
+//        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+//        private final LocalDateTime entryTime;
+//        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
+//        private final LocalDateTime answerOpenTime;
+//    }
+//
+//    @Getter
+//    @Builder
+//    @RequiredArgsConstructor
+//    @NoArgsConstructor(force = true)
+//    public static class ThemeAnalyticsResponse {
+//        private final Long themeId;
+//        private final Integer totalPlayCount;
+//        private final List<HintAnalyticsListResponse> hint;
+//    }
+//
+//    @Getter
+//    @Builder
+//    @RequiredArgsConstructor
+//    @NoArgsConstructor(force = true)
+//    public static class HintAnalyticsListResponse {
+//        private final Long id;
+//        private final Integer hintOpenCount;
+//        private final Integer answerOpenCount;
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -1,96 +1,96 @@
-package com.nextroom.nextRoomServer.dto;
-
-import com.nextroom.nextRoomServer.domain.Subscription;
-import com.nextroom.nextRoomServer.enums.EnumModel;
-import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
-import com.nextroom.nextRoomServer.enums.UserStatus;
-import com.nextroom.nextRoomServer.util.Timestamped;
-
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-public class SubscriptionDto {
-    @Getter
-    public static class UpdateSubscription {
-        private MessageData message;
-        private String subscription;
-    }
-
-    @Getter
-    public static class MessageData {
-        private String data;
-        private String messageId;
-        private String publishTime;
-
-    }
-
-    @Getter
-    public static class SubscriptionNotification {
-        private String version;
-        private Integer notificationType;
-        private String purchaseToken;
-        private String subscriptionId;
-    }
-
-    @Getter
-    public static class PublishedMessage {
-        private String version;
-        private String packageName;
-        private String eventTimeMillis;
-        private SubscriptionNotification subscriptionNotification;
-    }
-
-    @Getter
-    public static class SubscriptionInfoResponse {
-        private final Long id;
-        private final SubscriptionPlan subStatus;
-        private final String expiryDate;
-        private final String createdAt;
-
-        public SubscriptionInfoResponse(Subscription subscription) {
-            this.id = subscription.getId();
-            this.subStatus = subscription.getPlan();
-            this.expiryDate = subscription.getExpiryDate().toString();
-            this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
-        }
-    }
-
-    @Getter
-    public static class UserStatusResponse {
-        private final Long id;
-        private final UserStatus userStatus;
-        private final String expiryDate;
-        private final String createdAt;
-
-        public UserStatusResponse(Subscription subscription) {
-            this.id = subscription.getId();
-            this.userStatus = subscription.getStatus();
-            this.expiryDate = subscription.getExpiryDate().toString();
-            this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
-        }
-    }
-
-    @Getter
-    public static class SubscriptionPlanResponse {
-        private final String id;
-        private final String plan;
-        private final String description;
-        private final Integer originPrice;
-        private final Integer sellPrice;
-
-        public SubscriptionPlanResponse(EnumModel enumModel) {
-            this.id = enumModel.getId();
-            this.plan = enumModel.getPlan();
-            this.description = enumModel.getDescription();
-            this.originPrice = enumModel.getOriginPrice();
-            this.sellPrice = enumModel.getSellPrice();
-        }
-    }
-
-    @Getter
-    @RequiredArgsConstructor
-    public static class PurchaseSubscription {
-        private final String purchaseToken;
-        private final String subscriptionId;
-    }
-}
+//package com.nextroom.nextRoomServer.dto;
+//
+//import com.nextroom.nextRoomServer.domain.Subscription;
+//import com.nextroom.nextRoomServer.enums.EnumModel;
+//import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
+//import com.nextroom.nextRoomServer.enums.UserStatus;
+//import com.nextroom.nextRoomServer.util.Timestamped;
+//
+//import lombok.Getter;
+//import lombok.RequiredArgsConstructor;
+//
+//public class SubscriptionDto {
+//    @Getter
+//    public static class UpdateSubscription {
+//        private MessageData message;
+//        private String subscription;
+//    }
+//
+//    @Getter
+//    public static class MessageData {
+//        private String data;
+//        private String messageId;
+//        private String publishTime;
+//
+//    }
+//
+//    @Getter
+//    public static class SubscriptionNotification {
+//        private String version;
+//        private Integer notificationType;
+//        private String purchaseToken;
+//        private String subscriptionId;
+//    }
+//
+//    @Getter
+//    public static class PublishedMessage {
+//        private String version;
+//        private String packageName;
+//        private String eventTimeMillis;
+//        private SubscriptionNotification subscriptionNotification;
+//    }
+//
+//    @Getter
+//    public static class SubscriptionInfoResponse {
+//        private final Long id;
+//        private final SubscriptionPlan subStatus;
+//        private final String expiryDate;
+//        private final String createdAt;
+//
+//        public SubscriptionInfoResponse(Subscription subscription) {
+//            this.id = subscription.getId();
+//            this.subStatus = subscription.getPlan();
+//            this.expiryDate = subscription.getExpiryDate().toString();
+//            this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
+//        }
+//    }
+//
+//    @Getter
+//    public static class UserStatusResponse {
+//        private final Long id;
+//        private final UserStatus userStatus;
+//        private final String expiryDate;
+//        private final String createdAt;
+//
+//        public UserStatusResponse(Subscription subscription) {
+//            this.id = subscription.getId();
+//            this.userStatus = subscription.getStatus();
+//            this.expiryDate = subscription.getExpiryDate().toString();
+//            this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
+//        }
+//    }
+//
+//    @Getter
+//    public static class SubscriptionPlanResponse {
+//        private final String id;
+//        private final String plan;
+//        private final String description;
+//        private final Integer originPrice;
+//        private final Integer sellPrice;
+//
+//        public SubscriptionPlanResponse(EnumModel enumModel) {
+//            this.id = enumModel.getId();
+//            this.plan = enumModel.getPlan();
+//            this.description = enumModel.getDescription();
+//            this.originPrice = enumModel.getOriginPrice();
+//            this.sellPrice = enumModel.getSellPrice();
+//        }
+//    }
+//
+//    @Getter
+//    @RequiredArgsConstructor
+//    public static class PurchaseSubscription {
+//        private final String purchaseToken;
+//        private final String subscriptionId;
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionPlan.java
@@ -5,8 +5,8 @@ import java.util.Objects;
 
 public enum SubscriptionPlan implements EnumModel {
     MINI("mini_subscription", "미니", "2개의 테마를 등록할 수 있어요", 19900, 9900, 2),
-    MEDIUM("medium_subscription", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900, 3),
-    LARGE("large_subscription", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900, 4);
+    MEDIUM("medium_subscription", "미디움", "5개의 테마를 등록할 수 있어요", 29900, 14900, 5),
+    LARGE("large_subscription", "라지", "8개의 테마를 등록할 수 있어요", 39900, 19900, 8);
 
     private final String id;
     private final String plan;

--- a/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionStatus.java
+++ b/src/main/java/com/nextroom/nextRoomServer/enums/SubscriptionStatus.java
@@ -1,25 +1,25 @@
-package com.nextroom.nextRoomServer.enums;
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public enum SubscriptionStatus {
-    SUBSCRIPTION_RECOVERED(1), // 정기 결제가 계정 보류에서 복구되었습니다.
-    SUBSCRIPTION_RENEWED(2), // 활성 정기 결제가 갱신되었습니다.
-    SUBSCRIPTION_CANCELED(3), // 정기 결제가 자발적으로 또는 비자발적으로 취소되었습니다. 자발적 취소의 경우 사용자가 취소할 때 전송됩니다.
-    SUBSCRIPTION_PURCHASED(4), // 새로운 정기 결제가 구매되었습니다.
-    SUBSCRIPTION_ON_HOLD(5), // 정기 결제가 계정 보류 상태가 되었습니다(사용 설정된 경우).
-    SUBSCRIPTION_IN_GRACE_PERIOD(6), // 정기 결제가 유예 기간 상태로 전환되었습니다(사용 설정된 경우).
-    SUBSCRIPTION_RESTARTED(
-        7), // 사용자가 Play > 계정 > 정기 결제에서 정기 결제를 복원했습니다. 정기 결제가 취소되었지만 사용자가 복원할 때 아직 만료되지 않았습니다. 자세한 내용은 복원을 참고하세요.
-    SUBSCRIPTION_PRICE_CHANGE_CONFIRMED(8), // 사용자가 정기 결제 가격 변경을 확인했습니다.
-    SUBSCRIPTION_DEFERRED(9), // 구독 갱신 기한이 연장되었습니다.
-    SUBSCRIPTION_PAUSED(10), // 구독이 일시중지되었습니다.
-    SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED(11), // 정기 결제 일시중지 일정이 변경되었습니다.
-    SUBSCRIPTION_REVOKED(12), // 정기 결제가 만료 시간 전에 사용자에 의해 취소되었습니다.
-    SUBSCRIPTION_EXPIRED(13); // 정기 결제가 만료되었습니다.
-
-    private final Integer status;
-}
+//package com.nextroom.nextRoomServer.enums;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Getter;
+//
+//@Getter
+//@AllArgsConstructor
+//public enum SubscriptionStatus {
+//    SUBSCRIPTION_RECOVERED(1), // 정기 결제가 계정 보류에서 복구되었습니다.
+//    SUBSCRIPTION_RENEWED(2), // 활성 정기 결제가 갱신되었습니다.
+//    SUBSCRIPTION_CANCELED(3), // 정기 결제가 자발적으로 또는 비자발적으로 취소되었습니다. 자발적 취소의 경우 사용자가 취소할 때 전송됩니다.
+//    SUBSCRIPTION_PURCHASED(4), // 새로운 정기 결제가 구매되었습니다.
+//    SUBSCRIPTION_ON_HOLD(5), // 정기 결제가 계정 보류 상태가 되었습니다(사용 설정된 경우).
+//    SUBSCRIPTION_IN_GRACE_PERIOD(6), // 정기 결제가 유예 기간 상태로 전환되었습니다(사용 설정된 경우).
+//    SUBSCRIPTION_RESTARTED(
+//        7), // 사용자가 Play > 계정 > 정기 결제에서 정기 결제를 복원했습니다. 정기 결제가 취소되었지만 사용자가 복원할 때 아직 만료되지 않았습니다. 자세한 내용은 복원을 참고하세요.
+//    SUBSCRIPTION_PRICE_CHANGE_CONFIRMED(8), // 사용자가 정기 결제 가격 변경을 확인했습니다.
+//    SUBSCRIPTION_DEFERRED(9), // 구독 갱신 기한이 연장되었습니다.
+//    SUBSCRIPTION_PAUSED(10), // 구독이 일시중지되었습니다.
+//    SUBSCRIPTION_PAUSE_SCHEDULE_CHANGED(11), // 정기 결제 일시중지 일정이 변경되었습니다.
+//    SUBSCRIPTION_REVOKED(12), // 정기 결제가 만료 시간 전에 사용자에 의해 취소되었습니다.
+//    SUBSCRIPTION_EXPIRED(13); // 정기 결제가 만료되었습니다.
+//
+//    private final Integer status;
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/repository/HintHistoryRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/HintHistoryRepository.java
@@ -1,20 +1,20 @@
-package com.nextroom.nextRoomServer.repository;
-
-import java.util.List;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
-import com.nextroom.nextRoomServer.domain.HintHistory;
-
-public interface HintHistoryRepository extends JpaRepository<HintHistory, Long> {
-    @Query(value = "SELECT A.hint_id AS id, COUNT(A.hint_id) AS hintOpenCount, SUM(A.answer_count) AS answerOpenCount "
-        +
-        "FROM (SELECT hint_id, IF(answer_open_time IS NULL, 0, 1) AS answer_count " +
-        "FROM play_history PH " +
-        "INNER JOIN hint_history HH ON PH.play_history_id = HH.play_history_id " +
-        "WHERE PH.theme_id = :themeId) A " +
-        "GROUP BY A.hint_id", nativeQuery = true)
-    List<Object[]> findAnalyticsByThemeId(@Param("themeId") Long themeId);
-}
+//package com.nextroom.nextRoomServer.repository;
+//
+//import java.util.List;
+//
+//import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.data.jpa.repository.Query;
+//import org.springframework.data.repository.query.Param;
+//
+//import com.nextroom.nextRoomServer.domain.HintHistory;
+//
+//public interface HintHistoryRepository extends JpaRepository<HintHistory, Long> {
+//    @Query(value = "SELECT A.hint_id AS id, COUNT(A.hint_id) AS hintOpenCount, SUM(A.answer_count) AS answerOpenCount "
+//        +
+//        "FROM (SELECT hint_id, IF(answer_open_time IS NULL, 0, 1) AS answer_count " +
+//        "FROM play_history PH " +
+//        "INNER JOIN hint_history HH ON PH.play_history_id = HH.play_history_id " +
+//        "WHERE PH.theme_id = :themeId) A " +
+//        "GROUP BY A.hint_id", nativeQuery = true)
+//    List<Object[]> findAnalyticsByThemeId(@Param("themeId") Long themeId);
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/repository/PlayHistoryRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/PlayHistoryRepository.java
@@ -1,9 +1,9 @@
-package com.nextroom.nextRoomServer.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.nextroom.nextRoomServer.domain.PlayHistory;
-
-public interface PlayHistoryRepository extends JpaRepository<PlayHistory, Long> {
-    Integer countByThemeId(Long themeId);
-}
+//package com.nextroom.nextRoomServer.repository;
+//
+//import org.springframework.data.jpa.repository.JpaRepository;
+//
+//import com.nextroom.nextRoomServer.domain.PlayHistory;
+//
+//public interface PlayHistoryRepository extends JpaRepository<PlayHistory, Long> {
+//    Integer countByThemeId(Long themeId);
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/service/HistoryService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/HistoryService.java
@@ -1,103 +1,103 @@
-package com.nextroom.nextRoomServer.service;
-
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.nextroom.nextRoomServer.domain.Hint;
-import com.nextroom.nextRoomServer.domain.HintHistory;
-import com.nextroom.nextRoomServer.domain.PlayHistory;
-import com.nextroom.nextRoomServer.domain.Theme;
-import com.nextroom.nextRoomServer.dto.HistoryDto;
-import com.nextroom.nextRoomServer.exceptions.CustomException;
-import com.nextroom.nextRoomServer.repository.HintHistoryRepository;
-import com.nextroom.nextRoomServer.repository.HintRepository;
-import com.nextroom.nextRoomServer.repository.PlayHistoryRepository;
-import com.nextroom.nextRoomServer.repository.ThemeRepository;
-import com.nextroom.nextRoomServer.security.SecurityUtil;
-
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class HistoryService {
-    private final PlayHistoryRepository playHistoryRepository;
-    private final HintHistoryRepository hintHistoryRepository;
-    private final ThemeRepository themeRepository;
-    private final HintRepository hintRepository;
-
-    @Transactional
-    public void addHistory(HistoryDto.AddPlayHistoryRequest request) {
-        Theme theme = themeRepository.findById(request.getThemeId())
-            .orElseThrow(() -> new CustomException(TARGET_THEME_NOT_FOUND));
-
-        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
-            throw new CustomException(NOT_PERMITTED);
-        }
-
-        PlayHistory playHistory = PlayHistory.builder()
-            .theme(theme)
-            .gameStartTime(request.getGameStartTime())
-            .build();
-
-        playHistory = playHistoryRepository.saveAndFlush(playHistory);
-
-        for (HistoryDto.AddHintHistoryRequest hintHistoryRequest : request.getHint()) {
-            Hint hint = hintRepository.findById(hintHistoryRequest.getId()).orElseThrow(
-                () -> new CustomException(TARGET_HINT_NOT_FOUND));
-
-            HintHistory hintHistory = HintHistory.builder()
-                .playHistory(playHistory)
-                .hint(hint)
-                .entryTime(hintHistoryRequest.getEntryTime())
-                .answerOpenTime(hintHistoryRequest.getAnswerOpenTime())
-                .build();
-
-            hintHistoryRepository.save(hintHistory);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public HistoryDto.ThemeAnalyticsResponse getThemeAnalytics(Long themeId) {
-        Theme theme = themeRepository.findById(themeId)
-            .orElseThrow(() -> new CustomException(TARGET_THEME_NOT_FOUND));
-
-        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
-            throw new CustomException(NOT_PERMITTED);
-        }
-
-        List<Object[]> hintAnalyticsList = hintHistoryRepository.findAnalyticsByThemeId(
-            theme.getId());
-
-        List<HistoryDto.HintAnalyticsListResponse> hintAnalyticsListResponses = new ArrayList<>();
-        for (Object[] objects : hintAnalyticsList) {
-            Long hintId = (Long)objects[0];
-            Long hintOpenCount = (Long)objects[1];
-            BigDecimal answerCount = (BigDecimal)objects[2];
-
-            Integer convertedHintOpenCount = hintOpenCount != null ? hintOpenCount.intValue() : 0;
-            Integer convertedAnswerCount = answerCount != null ? answerCount.intValue() : 0;
-
-            HistoryDto.HintAnalyticsListResponse hintAnalyticsDto = HistoryDto.HintAnalyticsListResponse.builder()
-                .id(hintId)
-                .hintOpenCount(convertedHintOpenCount)
-                .answerOpenCount(convertedAnswerCount)
-                .build();
-            hintAnalyticsListResponses.add(hintAnalyticsDto);
-        }
-
-        Integer totalPlayCount = playHistoryRepository.countByThemeId(theme.getId());
-
-        return HistoryDto.ThemeAnalyticsResponse.builder()
-            .themeId(theme.getId())
-            .totalPlayCount(totalPlayCount)
-            .hint(hintAnalyticsListResponses)
-            .build();
-    }
-}
+//package com.nextroom.nextRoomServer.service;
+//
+//import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+//
+//import java.math.BigDecimal;
+//import java.util.ArrayList;
+//import java.util.List;
+//import java.util.Objects;
+//
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import com.nextroom.nextRoomServer.domain.Hint;
+//import com.nextroom.nextRoomServer.domain.HintHistory;
+//import com.nextroom.nextRoomServer.domain.PlayHistory;
+//import com.nextroom.nextRoomServer.domain.Theme;
+//import com.nextroom.nextRoomServer.dto.HistoryDto;
+//import com.nextroom.nextRoomServer.exceptions.CustomException;
+//import com.nextroom.nextRoomServer.repository.HintHistoryRepository;
+//import com.nextroom.nextRoomServer.repository.HintRepository;
+//import com.nextroom.nextRoomServer.repository.PlayHistoryRepository;
+//import com.nextroom.nextRoomServer.repository.ThemeRepository;
+//import com.nextroom.nextRoomServer.security.SecurityUtil;
+//
+//import lombok.RequiredArgsConstructor;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class HistoryService {
+//    private final PlayHistoryRepository playHistoryRepository;
+//    private final HintHistoryRepository hintHistoryRepository;
+//    private final ThemeRepository themeRepository;
+//    private final HintRepository hintRepository;
+//
+//    @Transactional
+//    public void addHistory(HistoryDto.AddPlayHistoryRequest request) {
+//        Theme theme = themeRepository.findById(request.getThemeId())
+//            .orElseThrow(() -> new CustomException(TARGET_THEME_NOT_FOUND));
+//
+//        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
+//            throw new CustomException(NOT_PERMITTED);
+//        }
+//
+//        PlayHistory playHistory = PlayHistory.builder()
+//            .theme(theme)
+//            .gameStartTime(request.getGameStartTime())
+//            .build();
+//
+//        playHistory = playHistoryRepository.saveAndFlush(playHistory);
+//
+//        for (HistoryDto.AddHintHistoryRequest hintHistoryRequest : request.getHint()) {
+//            Hint hint = hintRepository.findById(hintHistoryRequest.getId()).orElseThrow(
+//                () -> new CustomException(TARGET_HINT_NOT_FOUND));
+//
+//            HintHistory hintHistory = HintHistory.builder()
+//                .playHistory(playHistory)
+//                .hint(hint)
+//                .entryTime(hintHistoryRequest.getEntryTime())
+//                .answerOpenTime(hintHistoryRequest.getAnswerOpenTime())
+//                .build();
+//
+//            hintHistoryRepository.save(hintHistory);
+//        }
+//    }
+//
+//    @Transactional(readOnly = true)
+//    public HistoryDto.ThemeAnalyticsResponse getThemeAnalytics(Long themeId) {
+//        Theme theme = themeRepository.findById(themeId)
+//            .orElseThrow(() -> new CustomException(TARGET_THEME_NOT_FOUND));
+//
+//        if (!Objects.equals(theme.getShop().getId(), SecurityUtil.getRequestedShopId())) {
+//            throw new CustomException(NOT_PERMITTED);
+//        }
+//
+//        List<Object[]> hintAnalyticsList = hintHistoryRepository.findAnalyticsByThemeId(
+//            theme.getId());
+//
+//        List<HistoryDto.HintAnalyticsListResponse> hintAnalyticsListResponses = new ArrayList<>();
+//        for (Object[] objects : hintAnalyticsList) {
+//            Long hintId = (Long)objects[0];
+//            Long hintOpenCount = (Long)objects[1];
+//            BigDecimal answerCount = (BigDecimal)objects[2];
+//
+//            Integer convertedHintOpenCount = hintOpenCount != null ? hintOpenCount.intValue() : 0;
+//            Integer convertedAnswerCount = answerCount != null ? answerCount.intValue() : 0;
+//
+//            HistoryDto.HintAnalyticsListResponse hintAnalyticsDto = HistoryDto.HintAnalyticsListResponse.builder()
+//                .id(hintId)
+//                .hintOpenCount(convertedHintOpenCount)
+//                .answerOpenCount(convertedAnswerCount)
+//                .build();
+//            hintAnalyticsListResponses.add(hintAnalyticsDto);
+//        }
+//
+//        Integer totalPlayCount = playHistoryRepository.countByThemeId(theme.getId());
+//
+//        return HistoryDto.ThemeAnalyticsResponse.builder()
+//            .themeId(theme.getId())
+//            .totalPlayCount(totalPlayCount)
+//            .hint(hintAnalyticsListResponses)
+//            .build();
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -1,153 +1,153 @@
-package com.nextroom.nextRoomServer.service;
-
-import static com.nextroom.nextRoomServer.enums.SubscriptionPlan.*;
-import static com.nextroom.nextRoomServer.enums.UserStatus.*;
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
-
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.google.api.services.androidpublisher.model.SubscriptionPurchaseV2;
-import com.nextroom.nextRoomServer.domain.Shop;
-import com.nextroom.nextRoomServer.domain.Subscription;
-import com.nextroom.nextRoomServer.dto.SubscriptionDto;
-import com.nextroom.nextRoomServer.enums.EnumModel;
-import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
-import com.nextroom.nextRoomServer.enums.UserStatus;
-import com.nextroom.nextRoomServer.exceptions.CustomException;
-import com.nextroom.nextRoomServer.repository.ShopRepository;
-import com.nextroom.nextRoomServer.repository.SubscriptionRepository;
-import com.nextroom.nextRoomServer.security.SecurityUtil;
-import com.nextroom.nextRoomServer.util.AndroidPublisherClient;
-import com.nextroom.nextRoomServer.util.Timestamped;
-
-import lombok.RequiredArgsConstructor;
-
-@Service
-@RequiredArgsConstructor
-public class SubscriptionService {
-    private final SubscriptionRepository subscriptionRepository;
-    private final ShopRepository shopRepository;
-    private AndroidPublisherClient androidPublisherClient;
-
-    {
-        try {
-            androidPublisherClient = new AndroidPublisherClient();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public void test() {
-        Shop shop = shopRepository.findByAdminCode("12321").orElseThrow(
-            () -> new RuntimeException("ERROR"));
-
-        Subscription entity = Subscription.builder()
-            .shop(shop)
-            .status(SUBSCRIPTION)
-            .plan(MINI)
-            .expiryDate(LocalDate.now().plusDays(30))
-            .build();
-        subscriptionRepository.save(entity);
-    }
-
-    @Transactional(readOnly = true)
-    public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo() {
-        Long shopId = SecurityUtil.getRequestedShopId();
-        Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
-            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
-
-        return new SubscriptionDto.SubscriptionInfoResponse(subscription);
-    }
-
-    @Transactional
-    public SubscriptionDto.UserStatusResponse getUserStatus() {
-        Long shopId = SecurityUtil.getRequestedShopId();
-        Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
-            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
-
-        checkUserStatus(subscription);
-
-        return new SubscriptionDto.UserStatusResponse(subscription);
-    }
-
-    private void checkUserStatus(Subscription subscription) {
-        UserStatus status = subscription.getStatus();
-        LocalDate expiryDate = subscription.getExpiryDate();
-
-        if (status == FREE && expiryDate.isBefore(Timestamped.getToday())) {
-            subscription.updateStatus(HOLD, expiryDate.plusYears(1), null);
-            return;
-        }
-
-        if (status == HOLD && expiryDate.isBefore(Timestamped.getToday())) {
-            // subscriptionRepository.delete(subscription);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    public List<SubscriptionDto.SubscriptionPlanResponse> getSubscriptionPlan() {
-        return toEnumValues(SubscriptionPlan.class);
-    }
-
-    private List<SubscriptionDto.SubscriptionPlanResponse> toEnumValues(Class<? extends EnumModel> e) {
-        return Arrays
-            .stream(e.getEnumConstants())
-            .map(SubscriptionDto.SubscriptionPlanResponse::new)
-            .collect(Collectors.toList());
-    }
-
-    public void purchaseSubscription(String purchaseToken, String subscriptionId) throws IOException {
-        Long shopId = SecurityUtil.getRequestedShopId();
-        Shop shop = shopRepository.findById(shopId).orElseThrow(() -> new CustomException(TARGET_HINT_NOT_FOUND));
-
-        SubscriptionPurchaseV2 purchase = androidPublisherClient.getSubscriptionPurchase(purchaseToken);
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse(purchase.getLineItems().get(0).getExpiryTime(), formatter);
-        LocalDate expiryDate = zonedDateTime.toLocalDate();
-
-        String planId = purchase.getLineItems().get(0).getOfferDetails().getBasePlanId();
-
-        Subscription subscription = Subscription.builder()
-            .shop(shop)
-            .status(SUBSCRIPTION)
-            .plan(SubscriptionPlan.getSubscriptionPlanByPlanId(planId))
-            .expiryDate(expiryDate)
-            .purchaseToken(purchaseToken)
-            .build();
-
-        subscriptionRepository.save(subscription);
-
-        androidPublisherClient.acknowledgePurchase(purchaseToken, subscriptionId);
-    }
-
-    public void renew(String purchaseToken, String subscriptionId) throws IOException {
-        Subscription subscription = subscriptionRepository.findByPurchaseToken(purchaseToken)
-            .orElseThrow(() -> new CustomException(TARGET_SHOP_NOT_FOUND));
-
-        SubscriptionPurchaseV2 purchase = androidPublisherClient.getSubscriptionPurchase(purchaseToken);
-
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse(purchase.getLineItems().get(0).getExpiryTime(), formatter);
-        LocalDate expiryDate = zonedDateTime.toLocalDate();
-
-        subscription.renew(expiryDate);
-
-        androidPublisherClient.acknowledgePurchase(purchaseToken, subscriptionId);
-    }
-
-    public void expire(String purchaseToken) {
-        Subscription subscription = subscriptionRepository.findByPurchaseToken(purchaseToken)
-            .orElseThrow(() -> new CustomException(TARGET_SHOP_NOT_FOUND));
-        subscription.expire();
-    }
-}
+//package com.nextroom.nextRoomServer.service;
+//
+//import static com.nextroom.nextRoomServer.enums.SubscriptionPlan.*;
+//import static com.nextroom.nextRoomServer.enums.UserStatus.*;
+//import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+//
+//import java.io.IOException;
+//import java.time.LocalDate;
+//import java.time.ZonedDateTime;
+//import java.time.format.DateTimeFormatter;
+//import java.util.Arrays;
+//import java.util.List;
+//import java.util.stream.Collectors;
+//
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import com.google.api.services.androidpublisher.model.SubscriptionPurchaseV2;
+//import com.nextroom.nextRoomServer.domain.Shop;
+//import com.nextroom.nextRoomServer.domain.Subscription;
+//import com.nextroom.nextRoomServer.dto.SubscriptionDto;
+//import com.nextroom.nextRoomServer.enums.EnumModel;
+//import com.nextroom.nextRoomServer.enums.SubscriptionPlan;
+//import com.nextroom.nextRoomServer.enums.UserStatus;
+//import com.nextroom.nextRoomServer.exceptions.CustomException;
+//import com.nextroom.nextRoomServer.repository.ShopRepository;
+//import com.nextroom.nextRoomServer.repository.SubscriptionRepository;
+//import com.nextroom.nextRoomServer.security.SecurityUtil;
+//import com.nextroom.nextRoomServer.util.AndroidPublisherClient;
+//import com.nextroom.nextRoomServer.util.Timestamped;
+//
+//import lombok.RequiredArgsConstructor;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class SubscriptionService {
+//    private final SubscriptionRepository subscriptionRepository;
+//    private final ShopRepository shopRepository;
+////    private AndroidPublisherClient androidPublisherClient;
+//
+////    {
+////        try {
+////            androidPublisherClient = new AndroidPublisherClient();
+////        } catch (Exception e) {
+////            throw new RuntimeException(e);
+////        }
+////    }
+//
+//    public void test() {
+//        Shop shop = shopRepository.findByAdminCode("12321").orElseThrow(
+//            () -> new RuntimeException("ERROR"));
+//
+//        Subscription entity = Subscription.builder()
+//            .shop(shop)
+//            .status(SUBSCRIPTION)
+//            .plan(MINI)
+//            .expiryDate(LocalDate.now().plusDays(30))
+//            .build();
+//        subscriptionRepository.save(entity);
+//    }
+//
+//    @Transactional(readOnly = true)
+//    public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo() {
+//        Long shopId = SecurityUtil.getRequestedShopId();
+//        Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
+//            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
+//
+//        return new SubscriptionDto.SubscriptionInfoResponse(subscription);
+//    }
+//
+//    @Transactional
+//    public SubscriptionDto.UserStatusResponse getUserStatus() {
+//        Long shopId = SecurityUtil.getRequestedShopId();
+//        Subscription subscription = subscriptionRepository.findByShopId(shopId).orElseThrow(
+//            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
+//
+//        checkUserStatus(subscription);
+//
+//        return new SubscriptionDto.UserStatusResponse(subscription);
+//    }
+//
+//    private void checkUserStatus(Subscription subscription) {
+//        UserStatus status = subscription.getStatus();
+//        LocalDate expiryDate = subscription.getExpiryDate();
+//
+//        if (status == FREE && expiryDate.isBefore(Timestamped.getToday())) {
+//            subscription.updateStatus(HOLD, expiryDate.plusYears(1), null);
+//            return;
+//        }
+//
+//        if (status == HOLD && expiryDate.isBefore(Timestamped.getToday())) {
+//            // subscriptionRepository.delete(subscription);
+//        }
+//    }
+//
+//    @Transactional(readOnly = true)
+//    public List<SubscriptionDto.SubscriptionPlanResponse> getSubscriptionPlan() {
+//        return toEnumValues(SubscriptionPlan.class);
+//    }
+//
+//    private List<SubscriptionDto.SubscriptionPlanResponse> toEnumValues(Class<? extends EnumModel> e) {
+//        return Arrays
+//            .stream(e.getEnumConstants())
+//            .map(SubscriptionDto.SubscriptionPlanResponse::new)
+//            .collect(Collectors.toList());
+//    }
+//
+//    public void purchaseSubscription(String purchaseToken, String subscriptionId) throws IOException {
+//        Long shopId = SecurityUtil.getRequestedShopId();
+//        Shop shop = shopRepository.findById(shopId).orElseThrow(() -> new CustomException(TARGET_HINT_NOT_FOUND));
+//
+//        SubscriptionPurchaseV2 purchase = androidPublisherClient.getSubscriptionPurchase(purchaseToken);
+//
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+//        ZonedDateTime zonedDateTime = ZonedDateTime.parse(purchase.getLineItems().get(0).getExpiryTime(), formatter);
+//        LocalDate expiryDate = zonedDateTime.toLocalDate();
+//
+//        String planId = purchase.getLineItems().get(0).getOfferDetails().getBasePlanId();
+//
+//        Subscription subscription = Subscription.builder()
+//            .shop(shop)
+//            .status(SUBSCRIPTION)
+//            .plan(SubscriptionPlan.getSubscriptionPlanByPlanId(planId))
+//            .expiryDate(expiryDate)
+//            .purchaseToken(purchaseToken)
+//            .build();
+//
+//        subscriptionRepository.save(subscription);
+//
+//        androidPublisherClient.acknowledgePurchase(purchaseToken, subscriptionId);
+//    }
+//
+//    public void renew(String purchaseToken, String subscriptionId) throws IOException {
+//        Subscription subscription = subscriptionRepository.findByPurchaseToken(purchaseToken)
+//            .orElseThrow(() -> new CustomException(TARGET_SHOP_NOT_FOUND));
+//
+//        SubscriptionPurchaseV2 purchase = androidPublisherClient.getSubscriptionPurchase(purchaseToken);
+//
+//        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+//        ZonedDateTime zonedDateTime = ZonedDateTime.parse(purchase.getLineItems().get(0).getExpiryTime(), formatter);
+//        LocalDate expiryDate = zonedDateTime.toLocalDate();
+//
+//        subscription.renew(expiryDate);
+//
+//        androidPublisherClient.acknowledgePurchase(purchaseToken, subscriptionId);
+//    }
+//
+//    public void expire(String purchaseToken) {
+//        Subscription subscription = subscriptionRepository.findByPurchaseToken(purchaseToken)
+//            .orElseThrow(() -> new CustomException(TARGET_SHOP_NOT_FOUND));
+//        subscription.expire();
+//    }
+//}

--- a/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
@@ -48,7 +48,7 @@ public class ThemeService {
 
     @Transactional
     public void addTheme(ThemeDto.AddThemeRequest request) {
-        checkThemeLimitCount();
+//        checkThemeLimitCount();
 
         Theme theme = Theme.builder()
             .title(request.getTitle())
@@ -60,22 +60,22 @@ public class ThemeService {
         themeRepository.save(theme);
     }
 
-    private Integer getThemeLimitCount() {
-        Subscription subscription = subscriptionRepository.findByShopId(SecurityUtil.getRequestedShopId()).orElseThrow(
-            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
-
-        return subscription.getPlan().getThemeLimitCount();
-    }
-
-    private Integer getThemeCount() {
-        return themeRepository.countByShopId(SecurityUtil.getRequestedShopId());
-    }
-
-    private void checkThemeLimitCount() {
-        if (getThemeLimitCount() <= getThemeCount()) {
-            throw new CustomException(THEME_COUNT_EXCEEDED);
-        }
-    }
+//    private Integer getThemeLimitCount() {
+//        Subscription subscription = subscriptionRepository.findByShopId(SecurityUtil.getRequestedShopId()).orElseThrow(
+//            () -> new CustomException(TARGET_SHOP_NOT_FOUND));
+//
+//        return subscription.getPlan().getThemeLimitCount();
+//    }
+//
+//    private Integer getThemeCount() {
+//        return themeRepository.countByShopId(SecurityUtil.getRequestedShopId());
+//    }
+//
+//    private void checkThemeLimitCount() {
+//        if (getThemeLimitCount() <= getThemeCount()) {
+//            throw new CustomException(THEME_COUNT_EXCEEDED);
+//        }
+//    }
 
     @Transactional(readOnly = true)
     public List<ThemeDto.ThemeListResponse> getThemeList() {

--- a/src/main/java/com/nextroom/nextRoomServer/util/AndroidPublisherClient.java
+++ b/src/main/java/com/nextroom/nextRoomServer/util/AndroidPublisherClient.java
@@ -1,69 +1,69 @@
-package com.nextroom.nextRoomServer.util;
-
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
-import com.google.api.client.googleapis.services.GoogleClientRequestInitializer;
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpTransport;
-import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.gson.GsonFactory;
-import com.google.api.services.androidpublisher.AndroidPublisher;
-import com.google.api.services.androidpublisher.model.SubscriptionPurchaseV2;
-import com.google.api.services.androidpublisher.model.SubscriptionPurchasesAcknowledgeRequest;
-
-public class AndroidPublisherClient {
-
-    private static final String APPLICATION_NAME = "NextRoomApplication";
-    private static final String PACKAGE_NAME = "com.nextroom.nextroom";
-    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
-    private static final String CLIENT_SECRET_PATH = "src/main/resources/client_secret_90347533694-0uf0fm7rjghobhh534cv3ta3k38d5qru.apps.googleusercontent.com.json";
-    private static final String ACCESS_TOKEN_FILE_PATH = "src/main/resources/nextroom-server.token";
-    private static AndroidPublisher androidPublisher = null;
-
-    public static AndroidPublisher initializeAndroidPublisher() throws Exception {
-
-        HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
-        NextRoomHttpRequestInitializer httpRequestInitializer = new NextRoomHttpRequestInitializer();
-
-        GoogleClientRequestInitializer googleClientRequestInitializer = new GoogleClientRequestInitializer() {
-            @Override
-            public void initialize(AbstractGoogleClientRequest<?> request) throws IOException {
-                byte[] bytes = Files.readAllBytes(Paths.get(ACCESS_TOKEN_FILE_PATH));
-                String access_token = new String(bytes, StandardCharsets.UTF_8);
-
-                HttpHeaders headers = new HttpHeaders().setAuthorization("Bearer " + access_token);
-                // TODO handle exception
-                request.setRequestHeaders(headers);
-            }
-        };
-
-        return new AndroidPublisher.Builder(httpTransport, JSON_FACTORY, httpRequestInitializer)
-            .setApplicationName(APPLICATION_NAME)
-            .setGoogleClientRequestInitializer(googleClientRequestInitializer)
-            .build();
-    }
-
-    public AndroidPublisherClient() throws Exception {
-        androidPublisher = initializeAndroidPublisher();
-    }
-
-    public SubscriptionPurchaseV2 getSubscriptionPurchase(String purchaseToken) throws
-        IOException {
-        return androidPublisher
-            .purchases()
-            .subscriptionsv2()
-            .get(PACKAGE_NAME, purchaseToken).execute();
-    }
-
-    public void acknowledgePurchase(String purchaseToken, String subscriptionId) throws IOException {
-        SubscriptionPurchasesAcknowledgeRequest request = new SubscriptionPurchasesAcknowledgeRequest();
-        androidPublisher.purchases()
-            .subscriptions()
-            .acknowledge(PACKAGE_NAME, subscriptionId, purchaseToken, request);
-    }
-}
+//package com.nextroom.nextRoomServer.util;
+//
+//import java.io.IOException;
+//import java.nio.charset.StandardCharsets;
+//import java.nio.file.Files;
+//import java.nio.file.Paths;
+//
+//import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+//import com.google.api.client.googleapis.services.AbstractGoogleClientRequest;
+//import com.google.api.client.googleapis.services.GoogleClientRequestInitializer;
+//import com.google.api.client.http.HttpHeaders;
+//import com.google.api.client.http.HttpTransport;
+//import com.google.api.client.json.JsonFactory;
+//import com.google.api.client.json.gson.GsonFactory;
+//import com.google.api.services.androidpublisher.AndroidPublisher;
+//import com.google.api.services.androidpublisher.model.SubscriptionPurchaseV2;
+//import com.google.api.services.androidpublisher.model.SubscriptionPurchasesAcknowledgeRequest;
+//
+//public class AndroidPublisherClient {
+//
+//    private static final String APPLICATION_NAME = "NextRoomApplication";
+//    private static final String PACKAGE_NAME = "com.nextroom.nextroom";
+//    private static final JsonFactory JSON_FACTORY = GsonFactory.getDefaultInstance();
+//    private static final String CLIENT_SECRET_PATH = "src/main/resources/client_secret_90347533694-0uf0fm7rjghobhh534cv3ta3k38d5qru.apps.googleusercontent.com.json";
+//    private static final String ACCESS_TOKEN_FILE_PATH = "src/main/resources/nextroom-server.token";
+//    private static AndroidPublisher androidPublisher = null;
+//
+//    public static AndroidPublisher initializeAndroidPublisher() throws Exception {
+//
+//        HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
+//        NextRoomHttpRequestInitializer httpRequestInitializer = new NextRoomHttpRequestInitializer();
+//
+//        GoogleClientRequestInitializer googleClientRequestInitializer = new GoogleClientRequestInitializer() {
+//            @Override
+//            public void initialize(AbstractGoogleClientRequest<?> request) throws IOException {
+//                byte[] bytes = Files.readAllBytes(Paths.get(ACCESS_TOKEN_FILE_PATH));
+//                String access_token = new String(bytes, StandardCharsets.UTF_8);
+//
+//                HttpHeaders headers = new HttpHeaders().setAuthorization("Bearer " + access_token);
+//                // TODO handle exception
+//                request.setRequestHeaders(headers);
+//            }
+//        };
+//
+//        return new AndroidPublisher.Builder(httpTransport, JSON_FACTORY, httpRequestInitializer)
+//            .setApplicationName(APPLICATION_NAME)
+//            .setGoogleClientRequestInitializer(googleClientRequestInitializer)
+//            .build();
+//    }
+//
+//    public AndroidPublisherClient() throws Exception {
+//        androidPublisher = initializeAndroidPublisher();
+//    }
+//
+//    public SubscriptionPurchaseV2 getSubscriptionPurchase(String purchaseToken) throws
+//        IOException {
+//        return androidPublisher
+//            .purchases()
+//            .subscriptionsv2()
+//            .get(PACKAGE_NAME, purchaseToken).execute();
+//    }
+//
+//    public void acknowledgePurchase(String purchaseToken, String subscriptionId) throws IOException {
+//        SubscriptionPurchasesAcknowledgeRequest request = new SubscriptionPurchasesAcknowledgeRequest();
+//        androidPublisher.purchases()
+//            .subscriptions()
+//            .acknowledge(PACKAGE_NAME, subscriptionId, purchaseToken, request);
+//    }
+//}


### PR DESCRIPTION
### PR 타입
- [x] 기능 삭제 (#98)

### 반영 브랜치
feature/remove-subscription-analytics → develop

### 작업 사항
- 완성하지 못한 구독 결제 기능과 통계 기능을 제거합니다.
- 구독 결제의 경우, 추후 도입될 것을 가정하여 계정 생성 시 유저에 관한 구독 정보가 생성되는 부분은 주석 처리 하지 않았습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
postman 테스트 결과 이상 없으나, 빌드 테스트 한번 더 부탁드립니다!