### PR TITLE
[FEAT] 인증 메일 html template 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'

--- a/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
@@ -13,7 +13,7 @@ public enum StatusCode {
      * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    LOGIN_BAD_REQUEST(HttpStatus.BAD_REQUEST, "관리자 코드 또는 패스워드가 일치하지 않습니다."),
+    LOGIN_BAD_REQUEST(HttpStatus.BAD_REQUEST, "이메일 또는 패스워드가 일치하지 않습니다."),
     THEME_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "테마 생성 최대 개수를 초과하였습니다."),
     UNABLE_TO_SEND_EMAIL(HttpStatus.BAD_REQUEST, "이메일이 전송되지 않았습니다."),
 

--- a/src/main/java/com/nextroom/nextRoomServer/util/email/MailSender.java
+++ b/src/main/java/com/nextroom/nextRoomServer/util/email/MailSender.java
@@ -4,6 +4,8 @@ import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
 
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +13,8 @@ import com.nextroom.nextRoomServer.exceptions.CustomException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
 
 @Component
 @Slf4j
@@ -19,25 +23,42 @@ import lombok.extern.slf4j.Slf4j;
 public class MailSender {
 
     private final JavaMailSender emailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    private static final String MAIL_SUBJECT = "방탈출 힌트폰 서비스 '넥스트룸' 이메일 인증 번호 입니다.";
 
     public void sendEmail(String toEmail, String authCode) {
-        SimpleMailMessage emailForm = createEmailForm(toEmail, authCode);
+        MimeMessagePreparator emailHtmlForm = createHtmlEmailForm(toEmail, authCode);
         try {
-            emailSender.send(emailForm);
+            emailSender.send(emailHtmlForm);
         } catch (RuntimeException e) {
             log.debug("MailSender.sendEmail exception occur toEmail: {}, text: {}", toEmail, authCode);
             throw new CustomException(UNABLE_TO_SEND_EMAIL);
         }
     }
 
-    // 발신할 이메일 데이터 세팅
     private SimpleMailMessage createEmailForm(String toEmail, String authCode) {
         String text = "\uD83D\uDD11 회원 가입을 위해 아래의 인증 코드를 화면에 입력해주세요. 인증코드: " + authCode;
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(toEmail);
-        message.setSubject("방탈출 힌트폰 서비스 '넥스트룸' 이메일 인증 번호 입니다.");
+        message.setSubject(MAIL_SUBJECT);
         message.setText(text);
 
         return message;
+    }
+
+    private MimeMessagePreparator createHtmlEmailForm(String toEmail, String authCode) {
+        Context context = new Context();
+        context.setVariable("authCode", authCode);
+
+        return mimeMessage -> {
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "UTF-8");
+
+            String content = templateEngine.process("index.html", context);
+
+            helper.setTo(toEmail);
+            helper.setSubject(MAIL_SUBJECT);
+            helper.setText(content, true);
+        };
     }
 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <meta charset="UTF-8" name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>방탈출 힌트폰 서비스 '넥스트룸' 이메일 인증 번호 입니다.</title>
+</head>
+<body>
+    <section>
+        <div>
+            <p>
+                안녕하세요. 방탈출 힌트폰 서비스 넥스트룸 입니다.<br>
+                아래의 인증 번호를 화면에 입력하여 회원 가입을 완료해 주세요.
+            </p>
+            <p>
+                <b>🔑 인증 번호: <span th:text="${authCode}"></span></b>
+            </p>
+        </div>
+    </section>
+    <br>
+    <hr>
+    <footer>
+        <div>
+            <p>
+                이용 중에 도움이 필요하시면 아래 방법으로 문의 주세요.
+            </p>
+            <p>
+                💻 홈페이지에서 문의하기 <a href="https://nextroom.co.kr/" target="_blank">https://nextroom.co.kr/</a><br>
+
+                📮 이메일로 문의하기 <a href="mailto:nextroom.official@gmail.com" target="_blank">nextroom.official@gmail.com</a><br>
+
+                📝 넥스트룸 사용 가이드 보러가기 <a href="https://held-notebook-420.notion.site/134ed57b9c574733b31feab0ea5c36a5" target="_blank">https://www.notion.so/134ed57b9c574733b31feab0ea5c36a5?pvs=21</a>
+            </p>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/mail-html → develop

### 작업 사항
- 인증 메일 양식에 html template 적용
- 로그인 에러 문구 변경(관리자 코드 -> 이메일)

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
인증 메일 테스트 결과 이상 없습니다.