### PR TITLE
[FEAT] 가입 경로, 마지막 로그인 데이터 수집

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Comment;
 
 import com.nextroom.nextRoomServer.util.Timestamped;
 
@@ -37,7 +37,6 @@ public class Shop extends Timestamped {
     private String email;
 
     @Column(nullable = false, length = 5)
-    @ColumnDefault("00000")
     private String adminCode;
 
     @Column(nullable = false)
@@ -45,6 +44,10 @@ public class Shop extends Timestamped {
 
     @Column(nullable = false)
     private String name;
+
+    @Comment(value = "1: 웹(홈페이지)에서 PC로 들어온 유저, 2: 웹(홈페이지)에서 모바일로 들어온 유저, 3: 앱에서 들어온 유저")
+    @Column
+    private Integer type;
 
     @Column
     private String comment;

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -1,5 +1,6 @@
 package com.nextroom.nextRoomServer.domain;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -52,9 +53,16 @@ public class Shop extends Timestamped {
     @Enumerated(EnumType.STRING)
     private Authority authority;
 
+    @Column
+    private LocalDateTime lastLoginAt;
+
     @OneToMany(mappedBy = "shop", cascade = CascadeType.ALL)
     @Builder.Default
     private List<Theme> themes = new ArrayList<>();
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
 
     //    @OneToOne(mappedBy = "shop", cascade = CascadeType.DETACH)
     //    private Subscription subscription;

--- a/src/main/java/com/nextroom/nextRoomServer/dto/AuthDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/AuthDto.java
@@ -36,7 +36,7 @@ public class AuthDto {
     public static class SignUpRequestDto {
         @NotBlank(message = "이메일을 입력해 주세요.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
-        private final String email;
+        private String email;
         @Setter
         @NotEmpty(message = "비밀번호를 입력해 주세요.")
         @Pattern(regexp = PASSWORD_CONDITION_MIN_LENGTH_REGEX, message = "비밀번호는 최소 8자리 이상이어야 합니다.")
@@ -47,6 +47,7 @@ public class AuthDto {
         private String password;
         @NotBlank(message = "업체명을 입력해 주세요.")
         private String name;
+        private Integer type;
         @NotNull(message = "매장 오픈 여부를 입력해 주세요.")
         private Boolean isNotOpened;
 
@@ -59,6 +60,7 @@ public class AuthDto {
                 .adminCode(adminCode)
                 .password(passwordEncoder.encode(this.password))
                 .name(name)
+                .type(this.type)
                 .comment(comment)
                 .authority(Authority.ROLE_USER)
                 .build();
@@ -82,7 +84,7 @@ public class AuthDto {
     public static class LogInRequestDto {
         @NotBlank(message = "이메일을 입력해 주세요.")
         @Email(message = "이메일 형식이 올바르지 않습니다.")
-        private final String email;
+        private String email;
         @Setter
         @NotBlank(message = "비밀번호를 입력해 주세요.")
         private String password;

--- a/src/main/java/com/nextroom/nextRoomServer/service/AuthService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/AuthService.java
@@ -94,6 +94,8 @@ public class AuthService {
 
         refreshTokenRepository.save(refreshToken);
 
+        shop.updateLastLoginAt();
+
         return response;
     }
 


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/signup_data → develop

### 작업 사항
- 마지막 로그인 날짜를 추가 하였습니다.
- 가입 경로를 구분하기 위한 타입을 추가 하였습니다.
  1: 웹(홈페이지)에서 PC로 들어온 유저
  2: 웹(홈페이지)에서 모바일로 들어온 유저
  3: 앱에서 들어온 유저

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 이상 없습니다.