### PR TITLE
[CHORE] 테스트를 위한 Token 만료 시간 수정

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
@@ -33,8 +33,10 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
+//    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
+//    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60; // 1분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 3;  // 3분
 
     private final Key key;
 


### PR DESCRIPTION
### PR 타입
- [x] 테스트

### 반영 브랜치
feature/token-test → develop

### 작업 사항
- 안드로이드 테스트를 위해 토큰 만료 시간을 수정합니다
  - Access Token : 2시간 → 1분
  - Refresh Token : 14일 → 3분

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)