### PR TITLE
[CHORE] Token 만료 시간 연장

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/TokenProvider.java
@@ -33,10 +33,10 @@ import lombok.extern.slf4j.Slf4j;
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
     private static final String BEARER_TYPE = "Bearer";
-//    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
-//    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60; // 1분
-    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 3;  // 3분
+    //    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 2; // 2시간
+    //    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 14;  // 14일
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 5; // 5시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 30;  // 30일
 
     private final Key key;
 


### PR DESCRIPTION
### PR 타입
- [x] 코드 수정

### 반영 브랜치
feature/token-expire-time → develop

### 작업 사항
- 토큰 테스트가 완료되어 토큰 시간을 돌려놓았습니다.
- 토큰 갱신에 이슈가 있어 원인을 파악하기 위해 토큰 시간을 연장하였습니다.
  - Access Token : 1분 → 5시간
  - Refresh Token : 5분 → 30일

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
클라이언트 테스트가 필요합니다.