### PR TITLE
[FIX] shop ↔ payment 연관관계 변경

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/domain/Payment.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Payment.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +27,7 @@ public class Payment extends Timestamped {
     @Column(name = "payment_id", nullable = false)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "shop_id", nullable = false)
     private Shop shop;
 

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -65,6 +65,10 @@ public class Shop extends Timestamped {
     @Builder.Default
     private List<Theme> themes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "shop", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Payment> payments = new ArrayList<>();
+
     @OneToOne(mappedBy = "shop", cascade = CascadeType.ALL, orphanRemoval = true)
     private Subscription subscription;
 


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
fix/payment → develop

### 작업 사항
- 구독 결제 시, 동일한 고객사의 다른 결제 내역이 insert 되지 않는 이슈가 발생했습니다. payment 테이블의 shop_id 컬럼에 unique 제약 조건이 적용되어 있던 것이 원인으로 파악됩니다. 이에 따라 기존 `OneToOne`으로 맺어져 있던 shop과 payment의 연관관계를 `ManyToOne`으로 변경하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
안드로이드와의 구독 결제 테스트 결과 이상 없습니다.