### PR TITLE
[FEAT] 배너, 구독 요금제 조회 기능 추가

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/controller/BannerController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/BannerController.java
@@ -2,12 +2,14 @@ package com.nextroom.nextRoomServer.controller;
 
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.OK;
 
+import com.nextroom.nextRoomServer.dto.BannerDto;
 import com.nextroom.nextRoomServer.dto.BaseResponse;
 import com.nextroom.nextRoomServer.dto.DataResponse;
 import com.nextroom.nextRoomServer.service.BannerService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,7 +31,7 @@ public class BannerController {
         }
     )
     @GetMapping
-    public ResponseEntity<BaseResponse> getBannerList() {
+    public ResponseEntity<DataResponse<List<BannerDto>>> getBannerList() {
         return ResponseEntity.ok(new DataResponse<>(OK, bannerService.getBannerList()));
     }
 

--- a/src/main/java/com/nextroom/nextRoomServer/controller/BannerController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/BannerController.java
@@ -3,7 +3,6 @@ package com.nextroom.nextRoomServer.controller;
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.OK;
 
 import com.nextroom.nextRoomServer.dto.BannerDto;
-import com.nextroom.nextRoomServer.dto.BaseResponse;
 import com.nextroom.nextRoomServer.dto.DataResponse;
 import com.nextroom.nextRoomServer.service.BannerService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/src/main/java/com/nextroom/nextRoomServer/controller/BannerController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/BannerController.java
@@ -1,0 +1,36 @@
+package com.nextroom.nextRoomServer.controller;
+
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.OK;
+
+import com.nextroom.nextRoomServer.dto.BaseResponse;
+import com.nextroom.nextRoomServer.dto.DataResponse;
+import com.nextroom.nextRoomServer.service.BannerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Banner")
+@RestController
+@RequestMapping("/api/v1/banner")
+@RequiredArgsConstructor
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    @Operation(
+        summary = "배너 조회",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+        }
+    )
+    @GetMapping
+    public ResponseEntity<BaseResponse> getBannerList() {
+        return ResponseEntity.ok(new DataResponse<>(OK, bannerService.getBannerList()));
+    }
+
+}

--- a/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/SubscriptionController.java
@@ -1,31 +1,26 @@
 package com.nextroom.nextRoomServer.controller;
 
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.OK;
 
+import com.nextroom.nextRoomServer.dto.DataResponse;
 import com.nextroom.nextRoomServer.dto.SubscriptionDto;
+import com.nextroom.nextRoomServer.service.SubscriptionService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import com.nextroom.nextRoomServer.dto.BaseResponse;
-import com.nextroom.nextRoomServer.dto.DataResponse;
-import com.nextroom.nextRoomServer.service.SubscriptionService;
-
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 @Tag(name = "Subscription")
 @RestController
 @RequestMapping("/api/v1/subscription")
 @RequiredArgsConstructor
 public class SubscriptionController {
+
     private final SubscriptionService subscriptionService;
 
     @Operation(
@@ -65,7 +60,7 @@ public class SubscriptionController {
         }
     )
     @GetMapping("/plan")
-    public ResponseEntity<DataResponse<List<SubscriptionDto.SubscriptionPlanResponse>>> getSubscriptionPlan() {
+    public ResponseEntity<DataResponse<SubscriptionDto.SubscriptionPlanResponse>> getSubscriptionPlan() {
         return ResponseEntity.ok(new DataResponse<>(OK, subscriptionService.getSubscriptionPlan()));
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Banner.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Banner.java
@@ -1,0 +1,35 @@
+package com.nextroom.nextRoomServer.domain;
+
+import com.nextroom.nextRoomServer.util.Timestamped;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Banner extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "banner_id", nullable = false)
+    private Long id;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "url")
+    private String url;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+}

--- a/src/main/java/com/nextroom/nextRoomServer/dto/BannerDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/BannerDto.java
@@ -1,0 +1,11 @@
+package com.nextroom.nextRoomServer.dto;
+
+import com.nextroom.nextRoomServer.domain.Banner;
+
+public record BannerDto(String description, String url) {
+
+    public static BannerDto toDto(Banner banner) {
+        return new BannerDto(banner.getDescription(), banner.getUrl());
+    }
+
+}

--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -8,6 +8,7 @@ import com.nextroom.nextRoomServer.enums.UserStatus;
 import com.nextroom.nextRoomServer.util.Timestamped;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -77,7 +78,14 @@ public class SubscriptionDto {
     }
 
     @Getter
+    @Builder
     public static class SubscriptionPlanResponse {
+        private final String url;
+        private final List<SubscriptionPlan> plans;
+    }
+
+    @Getter
+    public static class SubscriptionPlan {
         private final Long id;
         private final String subscriptionProductId;
         private final String planId;
@@ -88,7 +96,7 @@ public class SubscriptionDto {
         private final Integer sellPrice;
         private final Integer discountRate;
 
-        public SubscriptionPlanResponse(Product product) {
+        public SubscriptionPlan(Product product) {
             this.id = product.getId();
             this.subscriptionProductId = product.getSubscriptionProductId();
             this.planId = product.getPlanId();

--- a/src/main/java/com/nextroom/nextRoomServer/repository/BannerRepository.java
+++ b/src/main/java/com/nextroom/nextRoomServer/repository/BannerRepository.java
@@ -1,0 +1,11 @@
+package com.nextroom.nextRoomServer.repository;
+
+import com.nextroom.nextRoomServer.domain.Banner;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    List<Banner> findAllByActiveTrue();
+
+}

--- a/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
@@ -68,7 +68,7 @@ public class SecurityConfig {
                     .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/**", "/api/v1/payment/**",
                         "/api/v1/email/**")
                     .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/api/v1/theme/**", "/api/v1/hint/**", "/api/v1/subscription/**")
+                    .requestMatchers(HttpMethod.GET, "/api/v1/theme/**", "/api/v1/hint/**", "/api/v1/subscription/**", "/api/v1/banner/**")
                     .permitAll() // TODO 구독 상태에 다른 권한 설정 필요
                     .requestMatchers("/api/v1/theme/**")
                     .hasAnyAuthority("ROLE_USER")

--- a/src/main/java/com/nextroom/nextRoomServer/service/BannerService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/BannerService.java
@@ -1,0 +1,29 @@
+package com.nextroom.nextRoomServer.service;
+
+import com.nextroom.nextRoomServer.domain.Banner;
+import com.nextroom.nextRoomServer.dto.BannerDto;
+import com.nextroom.nextRoomServer.repository.BannerRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    @Transactional(readOnly = true)
+    public List<BannerDto> getBannerList() {
+        return this.getActiveBannerList()
+            .stream()
+            .map(BannerDto::toDto)
+            .toList();
+    }
+
+    private List<Banner> getActiveBannerList() {
+        return bannerRepository.findAllByActiveTrue();
+    }
+
+}

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -2,11 +2,13 @@ package com.nextroom.nextRoomServer.service;
 
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.*;
 
+import com.nextroom.nextRoomServer.dto.SubscriptionDto.SubscriptionPlan;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -43,6 +45,9 @@ public class SubscriptionService {
     private final AndroidPurchaseUtils androidPurchaseUtils;
     private final ObjectMapper objectMapper;
 
+    @Value("${nextroom.plan-document-url}")
+    private String planDocumentUrl;
+
     @Transactional(readOnly = true)
     public SubscriptionDto.SubscriptionInfoResponse getSubscriptionInfo() {
         Long shopId = SecurityUtil.getCurrentShopId();
@@ -62,11 +67,15 @@ public class SubscriptionService {
     }
 
     @Transactional(readOnly = true)
-    public List<SubscriptionDto.SubscriptionPlanResponse> getSubscriptionPlan() {
+    public SubscriptionDto.SubscriptionPlanResponse getSubscriptionPlan() {
         List<Product> productList = productRepository.findAll();
-        return productList.stream()
-            .map(SubscriptionDto.SubscriptionPlanResponse::new)
-            .collect(Collectors.toList());
+        List<SubscriptionPlan> plans = productList.stream()
+            .map(SubscriptionPlan::new)
+            .toList();
+        return SubscriptionDto.SubscriptionPlanResponse.builder()
+            .url(planDocumentUrl)
+            .plans(plans)
+            .build();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 코드 리팩토링

### 반영 브랜치
feature/{banner} → develop

### 작업 사항
- 구독 요금제 조회 api 에 상세 페이지 링크 추가
- 배너 api 추가 (단일 배너)

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과를 적어주세요!