### PR TITLE
[FEAT] 구독 상태 검증 로직 추가

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -3,7 +3,11 @@ package com.nextroom.nextRoomServer.domain;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import com.nextroom.nextRoomServer.enums.UserStatus;
+import com.nextroom.nextRoomServer.exceptions.CustomException;
+import com.nextroom.nextRoomServer.security.SecurityUtil;
 import org.hibernate.annotations.Comment;
 
 import com.nextroom.nextRoomServer.util.Timestamped;
@@ -22,6 +26,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.NOT_PERMITTED;
+import static com.nextroom.nextRoomServer.exceptions.StatusCode.SUBSCRIPTION_NOT_PERMITTED;
 
 @Entity
 @Builder
@@ -74,5 +81,17 @@ public class Shop extends Timestamped {
 
     public void updateLastLoginAt() {
         this.lastLoginAt = LocalDateTime.now();
+    }
+
+    public void checkAuthorized() {
+        if (!Objects.equals(this.id, SecurityUtil.getCurrentShopId())) {
+            throw new CustomException(NOT_PERMITTED);
+        }
+    }
+
+    public void validateSubscription() {
+        if (this.subscription == null || this.subscription.getStatus() != UserStatus.SUBSCRIPTION) {
+            throw new CustomException(SUBSCRIPTION_NOT_PERMITTED);
+        }
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/dto/HintDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/HintDto.java
@@ -34,6 +34,13 @@ public class HintDto {
         private final int progress;
         private final List<String> hintImageList;
         private final List<String> answerImageList;
+
+        public boolean hasImages() {
+            boolean hasHintImages = this.hintImageList != null && !this.hintImageList.isEmpty();
+            boolean hasAnswerImages = this.answerImageList != null && !this.answerImageList.isEmpty();
+
+            return hasHintImages || hasAnswerImages;
+        }
     }
 
     @Getter

--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -57,8 +57,7 @@ public class SubscriptionDto {
         public SubscriptionInfoResponse(Subscription subscription) {
             this.id = subscription.getId();
             this.name = subscription.getShop().getName();
-            this.status = UserStatus.SUBSCRIPTION_EXPIRATION.equals(subscription.getStatus()) ?
-                UserStatus.FREE : subscription.getStatus();
+            this.status = subscription.getStatus();
             this.startDate = subscription.getStartDate();
             this.expiryDate = subscription.getExpiryDate();
             this.createdAt = Timestamped.dateTimeFormatter(subscription.getCreatedAt());
@@ -72,8 +71,7 @@ public class SubscriptionDto {
 
         public UserStatusResponse(Subscription subscription) {
             this.id = subscription.getId();
-            this.status = UserStatus.SUBSCRIPTION_EXPIRATION.equals(subscription.getStatus()) ?
-                UserStatus.FREE : subscription.getStatus();
+            this.status = subscription.getStatus();
         }
     }
 

--- a/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
@@ -34,6 +34,8 @@ public enum StatusCode {
      * 403 FORBIDDEN
      */
     NOT_PERMITTED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    SUBSCRIPTION_NOT_PERMITTED(HttpStatus.FORBIDDEN, "구독 권한이 없습니다."),
+
 
     /**
      * 404 Not Found


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/image-upload → develop

### 작업 사항
- presigned url 요청 시, 구독 상태를 검증하는 로직을 추가하였습니다.
- 힌트 등록 요청 시, 구독 상태와 request의 이미지 포함 여부를 검증하는 로직을 추가하였습니다.
- 구독 상태 조회 요청 시, '구독 만료(SUBSCRIPTION_EXPIRATION)' 상태를 정확히 표현해주기 위해 response를 수정하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 이상 없습니다.