### PR TITLE
[FEAT] Environment 검증 로직 추가

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
+++ b/src/main/java/com/nextroom/nextRoomServer/dto/SubscriptionDto.java
@@ -35,6 +35,11 @@ public class SubscriptionDto {
         private String packageName;
         private String eventTimeMillis;
         private SubscriptionNotification subscriptionNotification;
+        private TestNotification testNotification;
+
+        public boolean isTestNotification() {
+            return this.testNotification != null;
+        }
     }
 
     @Getter
@@ -43,6 +48,11 @@ public class SubscriptionDto {
         private int notificationType;
         private String purchaseToken;
         private String subscriptionId;
+    }
+
+    @Getter
+    public static class TestNotification {
+        private String version;
     }
 
     @Getter

--- a/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
+++ b/src/main/java/com/nextroom/nextRoomServer/exceptions/StatusCode.java
@@ -17,6 +17,8 @@ public enum StatusCode {
     THEME_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "테마 생성 최대 개수를 초과하였습니다."),
     UNABLE_TO_SEND_EMAIL(HttpStatus.BAD_REQUEST, "이메일이 전송되지 않았습니다."),
     INVALID_FILE_NAME(HttpStatus.BAD_REQUEST, "파일 이름이 유효하지 않습니다."),
+    ENVIRONMENT_DOES_NOT_MATCH(HttpStatus.BAD_REQUEST, "운영 환경이 일치하지 않습니다."),
+    PACKAGE_NAME_DOES_NOT_MATCH(HttpStatus.BAD_REQUEST, "패키지명이 일치하지 않습니다."),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 버그 수정

### 반영 브랜치
feature/purchase-env → develop

### 작업 사항
- RTDN의 모든 알림이 같은 구독으로 전달되더라도, 서버에서 환경을 구분하여 처리할 수 있도록 검증 로직을 추가하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
dev 서버 배포 후, 테스트 필요합니다.