### PR TITLE
[FEAT] Request, Response 로그 추가

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/config/FilterConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/config/FilterConfig.java
@@ -1,0 +1,18 @@
+package com.nextroom.nextRoomServer.config;
+
+import com.nextroom.nextRoomServer.filter.ContentCachingLoggingFilter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public FilterRegistrationBean<ContentCachingLoggingFilter> requestCachingFilter() {
+        FilterRegistrationBean<ContentCachingLoggingFilter> registrationBean = new FilterRegistrationBean<>();
+        registrationBean.setFilter(new ContentCachingLoggingFilter());
+        registrationBean.setOrder(0); // 가장 먼저 실행
+        return registrationBean;
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/config/InterceptorConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/config/InterceptorConfig.java
@@ -1,0 +1,19 @@
+package com.nextroom.nextRoomServer.config;
+
+import com.nextroom.nextRoomServer.interceptor.LoggingInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InterceptorConfig implements WebMvcConfigurer {
+    private final LoggingInterceptor loggingInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor)
+                .addPathPatterns("/**");
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/config/LoggingInterceptor.java
+++ b/src/main/java/com/nextroom/nextRoomServer/config/LoggingInterceptor.java
@@ -1,0 +1,93 @@
+package com.nextroom.nextRoomServer.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class LoggingInterceptor implements HandlerInterceptor {
+
+    private static final String REQUEST_ID = "requestId";
+    private static final int MAX_PAYLOAD_LENGTH = 1000;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        // 요청 ID 생성 및 MDC에 저장
+        String requestId = UUID.randomUUID().toString().substring(0, 8);
+        MDC.put(REQUEST_ID, requestId);
+
+        // Request 로깅
+        logRequest(new ContentCachingRequestWrapper(request));
+        return true;
+    }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) {
+        // Response 로깅
+        logResponse(new ContentCachingResponseWrapper(response), request);
+        MDC.clear();
+    }
+
+    private void logRequest(ContentCachingRequestWrapper request) {
+        StringBuilder logMessage = new StringBuilder();
+        logMessage.append(String.format("[REQ][%s] [%s] %s",
+            MDC.get(REQUEST_ID),
+            request.getMethod(),
+            request.getRequestURI()
+        ));
+
+        // Client IP
+        logMessage.append(" - Client IP: ")
+            .append(request.getRemoteAddr());
+
+        // Request Body
+        String contentType = request.getContentType();
+        if (contentType != null && !contentType.contains(MediaType.MULTIPART_FORM_DATA_VALUE)) {
+            String payload = getPayload(request.getContentAsByteArray());
+            if (!payload.isEmpty()) {
+                logMessage.append("\nBody: ").append(payload);
+            }
+        }
+
+        log.info(logMessage.toString());
+    }
+
+    private void logResponse(ContentCachingResponseWrapper response, HttpServletRequest request) {
+        StringBuilder logMessage = new StringBuilder();
+        logMessage.append(String.format("[RES][%s] [%s] %s [%d]",
+            MDC.get(REQUEST_ID),
+            request.getMethod(),
+            request.getRequestURI(),
+            response.getStatus()
+        ));
+
+        // Response Body
+        String payload = getPayload(response.getContentAsByteArray());
+        if (!payload.isEmpty()) {
+            logMessage.append("\nResponse: ").append(payload);
+        }
+
+        log.info(logMessage.toString());
+    }
+
+    private String getPayload(byte[] buf) {
+        if (buf == null || buf.length == 0) {
+            return "";
+        }
+        int length = Math.min(buf.length, MAX_PAYLOAD_LENGTH);
+        String payload = new String(buf, 0, length);
+        if (buf.length > MAX_PAYLOAD_LENGTH) {
+            payload += "... (truncated)";
+        }
+        return payload;
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/filter/ContentCachingLoggingFilter.java
+++ b/src/main/java/com/nextroom/nextRoomServer/filter/ContentCachingLoggingFilter.java
@@ -1,0 +1,24 @@
+package com.nextroom.nextRoomServer.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+
+public class ContentCachingLoggingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+
+        filterChain.doFilter(wrappingRequest, wrappingResponse);
+
+        wrappingResponse.copyBodyToResponse();
+
+    }
+}

--- a/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
+++ b/src/main/java/com/nextroom/nextRoomServer/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.nextroom.nextRoomServer.security.config;
 
+import com.nextroom.nextRoomServer.filter.ContentCachingLoggingFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -13,6 +14,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -46,6 +48,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+            .addFilterBefore(new ContentCachingLoggingFilter(), SecurityContextHolderAwareRequestFilter.class)
             .addFilterBefore(new ExceptionHandlerFilter(), UsernamePasswordAuthenticationFilter.class)
 
             .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -30,19 +30,8 @@
     </rollingPolicy>
   </appender>
 
-  <logger name="com.nextroom.nextRoomServer.dto" level="DEBUG"/>
-
-  <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
-    <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="FILE"/>
-  </logger>
-  <logger name="org.hibernate.type.descriptor.sql.BasicBinder" level="TRACE" additivity="false">
-    <appender-ref ref="CONSOLE"/>
-    <appender-ref ref="FILE"/>
-  </logger>
-
   <springProfile name="local">
-    <logger name="com.nextroom.nextRoomServer.dto" level="DEBUG"/>
+    <logger name="com.nextroom.nextRoomServer.*" level="DEBUG"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE" />
     </root>
@@ -50,7 +39,7 @@
 
   <springProfile name="dev">
     <property name="LOG_PATH" value="/home/ubuntu/app/logs"/>
-    <logger name="com.nextroom.nextRoomServer.dto" level="DEBUG"/>
+    <logger name="com.nextroom.nextRoomServer.*" level="DEBUG"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE" />
       <appender-ref ref="FILE" />
@@ -59,7 +48,7 @@
 
   <springProfile name="prod">
     <property name="LOG_PATH" value="/home/ubuntu/app/logs"/>
-    <logger name="com.nextroom.nextRoomServer.dto" level="DEBUG"/>
+    <logger name="com.nextroom.nextRoomServer.*" level="DEBUG"/>
     <root level="INFO">
       <appender-ref ref="CONSOLE" />
       <appender-ref ref="FILE" />


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [x] 코드 리팩토링

### 반영 브랜치
f/log → develop

### 작업 사항
- InterceptorConfig를 추가하였습니다.
- HttpServletRequest 인터페이스의 getInputStream() 데이터는 한 번만 읽을 수 있기 때문에 ContentCachingLoggingFilter를 추가하여 래핑하였습니다.
- getContentAsByteArray() 메서드는 캐싱된 데이터를 읽어오기 때문에 LoggingInterceptor의 preHandle이 아닌 afterCompletion에서 로그를 작성하였습니다.
- FilterConfig를 추가하여 SecurityFilter보다 CustomServletWrappingFilter가 먼저 실행될 수 있도록 설정하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 로그에 잘 찍히는 걸 확인했습니다.