### PR TITLE
[FEAT] 타이머 이미지 기능 수정

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/controller/HintController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/HintController.java
@@ -87,11 +87,11 @@ public class HintController {
     }
 
     @Operation(
-            summary = "PreSigned Url 요청",
+            summary = "힌트 or 정답 이미지 PreSigned Url 요청",
             description = """
                     s3 url /{profile}/{shopId}/{themeId}/{type}/{num}_uuid.png
 
-                    ex) "/dev/1/3/hint/1_2e20b6a9-e24b-45a8-a974-005c14f9f44f.png/"
+                    ex) "/dev/1/3/hint/1_2e20b6a9-e24b-45a8-a974-005c14f9f44f.png"
                     """,
             responses = {
                     @ApiResponse(responseCode = "200", description = "OK"),

--- a/src/main/java/com/nextroom/nextRoomServer/controller/ThemeController.java
+++ b/src/main/java/com/nextroom/nextRoomServer/controller/ThemeController.java
@@ -94,23 +94,64 @@ public class ThemeController {
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+            summary = "테마 타이머 배경 이미지 PreSigned Url 요청",
+            description = """
+                    s3 url /{profile}/{shopId}/{themeId}/{type}/{num}_uuid.png
+
+                    ex) "/dev/1/3/timer/1_2e20b6a9-e24b-45a8-a974-005c14f9f44f.png"
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+                    @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+                    @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+            }
+    )
     @GetMapping("/timer/url/{themeId}")
     public ResponseEntity<DataResponse<ThemeUrlResponse>> getUrl(@PathVariable Long themeId) {
         return ResponseEntity.ok(new DataResponse<>(OK, themeService.getTimerUrl(themeId)));
     }
 
+    @Operation(
+            summary = "테마 타이머 배경 이미지 추가",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+                    @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+                    @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+            }
+    )
     @PostMapping("/timer")
     public ResponseEntity<BaseResponse> addThemeTimerImage(@RequestBody @Valid ThemeDto.ThemeUrlRequest request) {
         themeService.addThemeTimerImage(request);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+            summary = "테마 타이머 배경 이미지 삭제",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+                    @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+                    @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+            }
+    )
     @DeleteMapping("/timer/{themeId}")
     public ResponseEntity<BaseResponse> removeTheme(@PathVariable Long themeId) {
         themeService.removeThemeTimerImage(themeId);
         return ResponseEntity.ok(new BaseResponse(OK));
     }
 
+    @Operation(
+            summary = "(앱) 테마 타이머 배경 on/off 설정",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "OK"),
+                    @ApiResponse(responseCode = "401", description = "TOKEN_UNAUTHORIZED"),
+                    @ApiResponse(responseCode = "403", description = "NOT_PERMITTED"),
+                    @ApiResponse(responseCode = "404", description = "TARGET_THEME_NOT_FOUND")
+            }
+    )
     @PutMapping("/timer/active")
     public ResponseEntity<BaseResponse> activeTimerUrl(@RequestBody @Valid ThemeDto.ThemeActiveUrlRequest request) {
         themeService.activeThemeTimerUrl(request);

--- a/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
@@ -1,6 +1,5 @@
 package com.nextroom.nextRoomServer.service;
 
-import static com.nextroom.nextRoomServer.exceptions.StatusCode.NOT_PERMITTED;
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.TARGET_SHOP_NOT_FOUND;
 import static com.nextroom.nextRoomServer.exceptions.StatusCode.TARGET_THEME_NOT_FOUND;
 
@@ -103,7 +102,7 @@ public class ThemeService {
         Long shopId = this.validateThemeAndShop(themeId)
             .getShop()
             .getId();
-        String timerUrl = s3Component.generatePresignedUrlsForUpload(shopId, themeId, TYPE_TIMER);
+        String timerUrl = s3Component.generatePresignedUrlForUpload(shopId, themeId, TYPE_TIMER);
 
         return new ThemeUrlResponse(themeId, timerUrl);
     }

--- a/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
@@ -81,8 +81,8 @@ public class ThemeService {
         List<Theme> themeList = themeRepository.findAllByShopId(SecurityUtil.getCurrentShopId());
         return themeList.stream()
             .map(it -> {
-                String timerImage = s3Component.generatePresignedUrlsForUpload(it.getShop().getId(), it.getId(), TYPE_TIMER);
-                return new ThemeDto.ThemeListResponse(it, timerImage);
+                String timerImageUrl = s3Component.generatePresignedUrlForDownLoad(it.getShop().getId(), it.getId(), TYPE_TIMER, it.getTimerImageUrl());
+                return new ThemeDto.ThemeListResponse(it, timerImageUrl);
             })
             .toList();
     }

--- a/src/main/java/com/nextroom/nextRoomServer/util/aws/S3Component.java
+++ b/src/main/java/com/nextroom/nextRoomServer/util/aws/S3Component.java
@@ -58,10 +58,17 @@ public class S3Component {
 
         List<String> imageUrlList = new ArrayList<>();
         for (String s : uuidList) {
-            String fileName = this.createFileNameForDownLoad(shopId, themeId, type, s);
-            imageUrlList.add(this.createPresignedGetUrl(fileName));
+            imageUrlList.add(this.generatePresignedUrlForDownLoad(shopId, themeId, type, s));
         }
         return imageUrlList;
+    }
+
+    public String generatePresignedUrlForDownLoad(Long shopId, Long themeId, String type, String timerImageUrl) {
+        if (timerImageUrl == null || timerImageUrl.isEmpty()) {
+            return null;
+        }
+        String fileName = this.createFileNameForDownLoad(shopId, themeId, type, timerImageUrl);
+        return this.createPresignedGetUrl(fileName);
     }
 
     public void deleteObjects(Long shopId, Long themeId, String type, List<String> imageList) {

--- a/src/main/java/com/nextroom/nextRoomServer/util/aws/S3Component.java
+++ b/src/main/java/com/nextroom/nextRoomServer/util/aws/S3Component.java
@@ -41,12 +41,12 @@ public class S3Component {
 
         List<String> imageUrlList = new ArrayList<>();
         for (int i = 1; i <= imageCount; i++) {
-            imageUrlList.add(generatePresignedUrlsForUpload(shopId, themeId, type));
+            imageUrlList.add(this.generatePresignedUrlForUpload(shopId, themeId, type));
         }
         return imageUrlList;
     }
 
-    public String generatePresignedUrlsForUpload(Long shopId, Long themeId, String type) {
+    public String generatePresignedUrlForUpload(Long shopId, Long themeId, String type) {
         String fileName = this.createFileNameForUpload(shopId, themeId, type, System.nanoTime());
         return this.createPresignedPutUrl(fileName);
     }


### PR DESCRIPTION
### PR 타입
- [x] 기능 수정

### 반영 브랜치
feature/timer-image → develop

### 작업 사항
- 테마 조회 api 중, 타이머 배경 이미지의 preisgned url 생성 부분 메서드를 수정하였습니다. (ForUpload -> ForDownLoad 로 변경)
  (참고로 ForUpload 메서드는 업로드를 위한 presigned url 생성, ForDownLoad 메서드는 다운로드 즉 존재하는 이미지 조회를 위한 presigned url 생성 메서드입니다.)
- 타이머 배경 api 에 Swagger 설명을 추가하였습니다.

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 이상 없습니다.