### PR TITLE
[FEAT] 구독 여부에 따른 타이머 이미지 active 상태 변경

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Shop.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import com.nextroom.nextRoomServer.enums.UserStatus;
 import com.nextroom.nextRoomServer.exceptions.CustomException;
@@ -89,10 +90,19 @@ public class Shop extends Timestamped {
         }
     }
 
+    public boolean isSubscription() {
+        return this.subscription.getStatus() == UserStatus.SUBSCRIPTION;
+    }
+
     public void validateSubscriptionInNeed(boolean needed) {
         if (!needed) { return; }
-        if (this.subscription == null || this.subscription.getStatus() != UserStatus.SUBSCRIPTION) {
+        if (this.subscription == null || !this.isSubscription()) {
             throw new CustomException(SUBSCRIPTION_NOT_PERMITTED);
         }
+    }
+
+    public void setAllUseTimerUrl(boolean active) {
+        this.themes.forEach(theme -> Optional.ofNullable(theme.getTimerImageUrl())
+                .ifPresent(it -> theme.setUseTimerUrl(active)));
     }
 }

--- a/src/main/java/com/nextroom/nextRoomServer/domain/Theme.java
+++ b/src/main/java/com/nextroom/nextRoomServer/domain/Theme.java
@@ -14,7 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -64,8 +64,8 @@ public class Theme extends Timestamped {
         this.hintLimit = request.getHintLimit();
     }
 
-    public void updateTimerImage(String timerImageUrl) {
-        this.useTimerImage = Optional.ofNullable(useTimerImage).orElse(false);
+    public void updateTimerImageActive(String timerImageUrl) {
+        this.useTimerImage = true;
         this.timerImageUrl = timerImageUrl;
     }
 

--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -119,6 +119,9 @@ public class SubscriptionService {
 
         // confirm Google API payment
         androidPurchaseUtils.acknowledge(purchaseToken, product.getSubscriptionProductId());
+
+        // update theme timer image active all
+        shop.setAllUseTimerUrl(true);
     }
 
     @Transactional
@@ -182,6 +185,9 @@ public class SubscriptionService {
 
         // update subscription
         subscription.expire();
+
+        // update theme timer image deactive all
+        subscription.getShop().setAllUseTimerUrl(false);
     }
 
     private Shop getShop(Long shopId) {

--- a/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/ThemeService.java
@@ -110,7 +110,12 @@ public class ThemeService {
     @Transactional
     public void addThemeTimerImage(final ThemeUrlRequest request) {
         Theme theme = validateThemeAndShop(request.getThemeId());
-        theme.updateTimerImage(request.getImageUrl());
+        Shop shop = theme.getShop();
+
+        if (!shop.isSubscription()) {
+            shop.setAllUseTimerUrl(false);
+        }
+        theme.updateTimerImageActive(request.getImageUrl());
     }
 
     @Transactional


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가

### 반영 브랜치
feature/timer-image → develop

### 작업 사항
- 타이머 이미지 추가 시, 구독 여부에 따라 다른 active 상태로 저장
  - 구독 상태일 경우, 모두 active로 저장
  - 미구독 상태일 경우, 현재 저장하려는 이미지만 active, 나머지는 deacive로 저장
- 구독 상태 변경 시, 타이머 이미지 active 상태 변경
  - 구독 시, 전체 타이머 이미지 active로 변경
  - 구독 만료 시, 전체 타이머 이미지 deactive로 변경

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
테스트 결과 이상 없습니다.