### PR TITLE
[FIX] 구독 결제 보류 상태 대응

### DIFF
--- a/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
+++ b/src/main/java/com/nextroom/nextRoomServer/service/SubscriptionService.java
@@ -132,9 +132,9 @@ public class SubscriptionService {
         NotificationType notificationType = NotificationType.of(subscriptionNotification.getNotificationType());
 
         switch (notificationType) {
-            case SUBSCRIPTION_RENEWED -> renew(purchaseToken);
-            case SUBSCRIPTION_EXPIRED -> expire(purchaseToken);
-            default -> log.debug("Unsupported notification type: {}", subscriptionNotification.getNotificationType());
+            case SUBSCRIPTION_RENEWED, SUBSCRIPTION_RECOVERED -> renew(purchaseToken);
+            case SUBSCRIPTION_EXPIRED, SUBSCRIPTION_ON_HOLD -> expire(purchaseToken);
+            default -> log.info("Unsupported notification type: {}", subscriptionNotification.getNotificationType());
         }
     }
 


### PR DESCRIPTION
### PR 타입
- [x] 버그 수정

### 반영 브랜치
feature/rtdn-on-hold → develop

### 작업 사항
- 구독 결제의 계정 보류 상태 대응을 위해 다음과 같이 처리하였습니다.
  - 계정 보류 시, 만료 처리
  - 계정 보류 복구 시, 갱신 처리

### 체크리스트
- [x] 빌드에 성공했나요?
- [x] 코드 컨벤션을 잘 지켰나요? (`cmd` + `opt` + `L`)

### 테스트 결과
rtdn 테스트 필요합니다.